### PR TITLE
Bug/typesense search not working properly

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -45,3 +45,25 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build  # Path to the built files
           keep_files: true  # Keeps existing files in the gh-pages branch
+
+  run-scraper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Prepare config string
+        id: prep
+        run: |
+          CONFIG=$(jq -c . config.json)
+          echo "CONFIG=$CONFIG" >> $GITHUB_ENV
+
+      - name: Run docsearch-scraper
+        run: |
+          docker run -i --env-file .env \
+            -e CONFIG="${{ env.CONFIG }}" \
+            typesense/docsearch-scraper:0.11.0

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -47,7 +47,15 @@ jobs:
           keep_files: true  # Keeps existing files in the gh-pages branch
 
   run-scraper:
+    needs: build-and-deploy
     runs-on: ubuntu-latest
+
+    env:
+      TYPESENSE_API_KEY: ${{ secrets.TYPESENSE_API_KEY }}
+      TYPESENSE_HOST: ${{ secrets.TYPESENSE_HOST }}
+      TYPESENSE_PORT: ${{ secrets.TYPESENSE_PORT }}
+      TYPESENSE_PROTOCOL: ${{ secrets.TYPESENSE_PROTOCOL }}
+      TYPESENSE_COLLECTION_NAME: ${{ secrets.TYPESENSE_COLLECTION_NAME }}
 
     steps:
       - name: Checkout repository
@@ -56,10 +64,18 @@ jobs:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
 
+      - name: Create .env file
+        run: |
+          echo "TYPESENSE_API_KEY=${{ secrets.TYPESENSE_API_KEY }}" > .env
+          echo "TYPESENSE_HOST=${{ secrets.TYPESENSE_HOST }}" >> .env
+          echo "TYPESENSE_PORT=${{ secrets.TYPESENSE_PORT }}" >> .env
+          echo "TYPESENSE_PROTOCOL=${{ secrets.TYPESENSE_PROTOCOL }}" >> .env
+          echo "TYPESENSE_COLLECTION_NAME=${{ secrets.TYPESENSE_COLLECTION_NAME }}" >> .env
+
       - name: Prepare config string
         id: prep
         run: |
-          CONFIG=$(jq -c . config.json)
+          CONFIG=$(jq -c . typesense-config.json)
           echo "CONFIG=$CONFIG" >> $GITHUB_ENV
 
       - name: Run docsearch-scraper


### PR DESCRIPTION
This pull request introduces a new `run-scraper` job to the GitHub Actions workflow to integrate a Typesense-powered document search scraper. The job is designed to run after the `build-and-deploy` step and handles setup, configuration, and execution of the scraper using Docker.

### Workflow Enhancements:
* **New `run-scraper` job**: Added a job to execute the Typesense document search scraper. It includes environment variable setup using secrets, configuration preparation with `jq`, and running the scraper via a Docker container. (`.github/workflows/build-deploy.yml`, [.github/workflows/build-deploy.ymlR48-R85](diffhunk://#diff-0a2a3bb14d8c517cf697b681cbf4137c0e7cadba0290cac39ed87fd484a5698aR48-R85))