### PR TITLE
made the following changes for the script API

### DIFF
--- a/docs/appendix/script-api/material-script-api/delete-material-classes.md
+++ b/docs/appendix/script-api/material-script-api/delete-material-classes.md
@@ -39,5 +39,5 @@ If the material class that's being deleted has a reference, an ApiResponse Objec
 
 ```python
 # Delete all material classes by the given IDs or paths
-system.mes.material.deleteMaterialClass(['RAW', 'IRB'])
+system.mes.material.deleteMaterialClasses(['RAW', 'IRB'])
 ```

--- a/docs/appendix/script-api/material-script-api/delete-property-values-for.md
+++ b/docs/appendix/script-api/material-script-api/delete-property-values-for.md
@@ -40,5 +40,5 @@ If the property value that's being deleted has a reference, an ApiResponse Objec
 
 ```python
 # Delete all material property values by the material path and property names
-system.mes.material.deletePropertyValueFor('IRB/5391537510212', ['Density', 'Melting Point'])
+system.mes.material.deletePropertyValuesFor('IRB/5391537510212', ['Density', 'Melting Point'])
 ```

--- a/docs/appendix/script-api/material-script-api/does-material-exist.md
+++ b/docs/appendix/script-api/material-script-api/does-material-exist.md
@@ -28,7 +28,7 @@ Returns a boolean indicating whether the material exists.
 
 ```python
 # Check whether the material exists
-material_exists = system.mes.material.doesMaterialExist('5391537510212')
+material_exists = system.mes.material.doesMaterialExist('IRB/5391537510212')
 
 # Output the boolean result
 print(material_exists)

--- a/docs/appendix/script-api/material-script-api/get-properties-for-material-class.md
+++ b/docs/appendix/script-api/material-script-api/get-properties-for-material-class.md
@@ -4,7 +4,7 @@ title: "getPropertiesForMaterialClass"
 description: "Retrieves all material properties for a material class."
 ---
 
-# system.mes.material.getProperty
+# system.mes.material.getPropertiesForMaterialClass
 
 ## Description
 

--- a/docs/appendix/script-api/material-script-api/get-property-value.md
+++ b/docs/appendix/script-api/material-script-api/get-property-value.md
@@ -43,7 +43,7 @@ Returns a JSON representation of the material property value. Returns nothing if
 
 ```python
 # Retrieve a material property value by its ID
-property_value = system.mes.material.getPropertyValueFor('01JRDP4APW-5D56ZQ8C-8949XKYT')
+property_value = system.mes.material.getPropertyValue('01JRDP4APW-5D56ZQ8C-8949XKYT')
 
 # Output the material property value
 print(property_value)

--- a/docs/appendix/script-api/material-script-api/get-property-values-for-material.md
+++ b/docs/appendix/script-api/material-script-api/get-property-values-for-material.md
@@ -44,7 +44,7 @@ Returns a JSON representation of the material property value. Returns nothing if
 
 ```python
 # Retrieve all material property values by material ID or path
-property_values = system.mes.material.getPropertyValueFor('IRB/5391537510212')
+property_values = system.mes.material.getPropertyValuesForMaterial('IRB/5391537510212')
 
 # Output the material property values
 print(property_values)

--- a/docs/appendix/script-api/material-script-api/new-material-reason-code.md
+++ b/docs/appendix/script-api/material-script-api/new-material-reason-code.md
@@ -47,6 +47,7 @@ new_material_reason_code = system.mes.material.newMaterialReasonCode()
 # Set basic attributes for the new material reason code
 new_material_reason_code['lotRecordType'] = 'CONSUME'
 new_material_reason_code['reasonCode'] = 'SCRP001'
+new_material_reason_code['requiredComments'] = True
 # (You can continue setting other properties as needed here)
 
 # Save the new material reason code to the system

--- a/docs/appendix/script-api/material-script-api/save-material-reason-code.md
+++ b/docs/appendix/script-api/material-script-api/save-material-reason-code.md
@@ -42,6 +42,7 @@ Returns a JSON representation of the saved material reason code.
 new_material_reason_code = system.mes.material.newMaterialReasonCode()
 new_material_reason_code['lotRecordType'] = 'CONSUME'
 new_material_reason_code['reasonCode'] = 'SCRP001'
+material_reason_code_data['requireComments'] = True
 saved_material_reason_code = system.mes.material.saveMaterialReasonCode(**new_material_reason_code)
 
 # Output the JSON representation of the saved material reason code

--- a/docs/appendix/script-api/production-order-script-api/new-production-order.md
+++ b/docs/appendix/script-api/production-order-script-api/new-production-order.md
@@ -26,16 +26,16 @@ system.mes.productionOrder.newProductionOrder()
 Returns a JSON representation of the newly created production order object. The following is a list of keys and default values:
 
 | Key                 | Default Value |
-| ------------------- | ------------- |
+| ------------------- |---------------|
 | `name`              | `null`        |
 | `productId`         | `null`        |
 | `customerId`        | `null`        |
 | `locationId`        | `null`        |
 | `status`            | `IDLE`        |
 | `schedulePriority`  | `NORMAL`      |
-| `quantity`          | `0`           |
-| `quantityProduced`  | `0`           |
-| `quantityScheduled` | `0`           |
+| `quantity`          | `0.0`         |
+| `quantityProduced`  | `0.0`         |
+| `quantityScheduled` | `0.0`         |
 | `startDate`         | `null`        |
 | `endDate`           | `null`        |
 | `dueDate`           | `null`        |

--- a/docs/appendix/script-api/schedule-script-api/find-schedules.md
+++ b/docs/appendix/script-api/schedule-script-api/find-schedules.md
@@ -24,18 +24,18 @@ system.mes.schedule.findSchedules(**queryRequest)
 
 Returns a Query Result object with the following properties:
 
-| Type                                                            | Name          | Description                                                                                                      |
-|-----------------------------------------------------------------| ------------- | ---------------------------------------------------------------------------------------------------------------- |
-| List\<[Recipe](../../data-model/schedule-model/schedule.md)> | content       | The list of all records found that meet the specified criteria                                                   |
-| Integer                                                         | totalPages    | If pagination is used, this is the number of total pages of records in the database for the specified page size. |
-| Long                                                            | totalElements | If pagination is used, this is the number of records in the database that meet the specified criteria.           |
-| Integer                                                         | pageSize      | If pagination is used, this is the specified page size.                                                          |
-| Integer                                                         | pageIndex     | If pagination is used, this is the specified page index.                                                         |
-| Boolean                                                         | hasContent    | True if an records were found that meet the specified criteria.                                                  |
-| Boolean                                                         | isFirst       | If pagination is used, this is true if the first page was returned.                                              |
-| Boolean                                                         | isLast        | If pagination is used, this is true if the last page was returned.                                               |
-| Boolean                                                         | hasNext       | If pagination is used, this is true if there is a page of content available after this one.                      |
-| Boolean                                                         | hasPrevious   | If pagination is used, this is true if there is a page of content available before this one.                     |
+| Name            | Type                                                           | Description                                                                                                      |
+|-----------------|----------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| `content`       | `List`\<[Recipe](../../data-model/schedule-model/schedule.md)> | The list of all records found that meet the specified criteria                                                   |
+| `totalPages`    | `Integer`                                                      | If pagination is used, this is the number of total pages of records in the database for the specified page size. |
+| `totalElements` | `Long`                                                         | If pagination is used, this is the number of records in the database that meet the specified criteria.           |
+| `pageSize`      | `Integer`                                                      | If pagination is used, this is the specified page size.                                                          |
+| `pageIndex`     | `Integer`                                                      | If pagination is used, this is the specified page index.                                                         |
+| `hasContent`    | `Boolean`                                                      | True if an records were found that meet the specified criteria.                                                  |
+| `isFirst`       | `Boolean`                                                      | If pagination is used, this is true if the first page was returned.                                              |
+| `isLast`        | `Boolean`                                                      | If pagination is used, this is true if the last page was returned.                                               |
+| `hasNext`       | `Boolean`                                                      | If pagination is used, this is true if there is a page of content available after this one.                      |
+| `hasPrevious`   | `Boolean`                                                      | If pagination is used, this is true if there is a page of content available before this one.                     |
 
 ## Code Examples
 

--- a/docs/appendix/script-api/unit-of-measure-script-api/does-conversion-exist.md
+++ b/docs/appendix/script-api/unit-of-measure-script-api/does-conversion-exist.md
@@ -30,7 +30,7 @@ Returns a boolean indicating whether the unit of measure conversion exists.
 
 ```python
 # Check whether the unit of measure conversion exists
-uomc_exists = system.mes.unitOfMeasure.doesUnitOfMeasureExist('Pound', 'Kg', '01JCH3TP3Y-4B080WHN-MSR8RVP5')
+uomc_exists = system.mes.unitOfMeasure.doesConversionExist('Pound', 'Kilogram', '01JCH3TP3Y-4B080WHN-MSR8RVP5')
 
 # Output the boolean result
 print(uomc_exists)

--- a/docs/appendix/script-api/unit-of-measure-script-api/find-units-of-measure.md
+++ b/docs/appendix/script-api/unit-of-measure-script-api/find-units-of-measure.md
@@ -66,7 +66,7 @@ filters = [filterRequest]
 queryRequest['filters'] = filters
 
 # Retrieve the units of measure that match the filter
-result = system.mes.unitOfMeasure.findUnitOfMeasure(**queryRequest)
+result = system.mes.unitOfMeasure.findUnitsOfMeasure(**queryRequest)
 
 # Output the units of measure that match the filter.
 print(result)

--- a/docs/appendix/script-api/unit-of-measure-script-api/get-conversion-for.md
+++ b/docs/appendix/script-api/unit-of-measure-script-api/get-conversion-for.md
@@ -32,7 +32,7 @@ Returns a JSON representation of the unit of measure conversion. Returns nothing
 
 ```python
 # Retrieve a unit of measure conversion by the units of measure and the material ID.
-uomc = system.mes.unitOfMeasure.getUnitOfMeasureConversion('Pound', 'Kg', '01JCH3TP3Y-4B080WHN-MSR8RVP5')
+uomc = system.mes.unitOfMeasure.getConversionFor('Pound', 'Kilogram', '01JCH3TP3Y-4B080WHN-MSR8RVP5')
 
 # Output the unit of measure conversion
 print(uomc)

--- a/docs/appendix/script-api/unit-of-measure-script-api/save-unit-of-measure-conversion.md
+++ b/docs/appendix/script-api/unit-of-measure-script-api/save-unit-of-measure-conversion.md
@@ -39,7 +39,7 @@ Returns a JSON representation of the saved unit of measure conversion.
 
 ```python
 # Generate the object structure for a new unit of measure conversion object, set the parameters and save it
-new_uom = system.mes.unitOfMeasure.newUnitOfMeasureConversion()
+new_uomc = system.mes.unitOfMeasure.newUnitOfMeasureConversion()
 new_uomc['toId'] = '01JCH3T85P-KVCB8ZR5-0B83A3SX'
 new_uomc['conversionFactor'] = '0.33'
 new_uomc['fromId'] = '01JCH4NB3J-BTERAZ27-QEQQN4ME'


### PR DESCRIPTION
method name | state | effort | location | notes
-- | -- | -- | -- | --
system.mes.material.deleteMaterialClasses | incorrect | XXS | Code Examples:   code typo | change   'system.mes.material.deleteMaterialClass(['RAW', 'IRB'])' to   'system.mes.material.deleteMaterialClasses(['RAW', 'IRB'])'
system.mes.material.doesMaterialExist | incorrect | XXS | Code Examples: code   errors | input param is not a   path or ID. replace the input param, '5391537510212', with   'IRB/5391537510212'
system.mes.material.getPropertiesForMaterialClass | incorrect | XXS | Title | title is incorrect
system.mes.material.getPropertyValue | incorrect | XXS | Code Examples: code   typo | change   'system.mes.material.getPropertyValueFor('01JRDP4APW-5D56ZQ8C-8949XKYT')' to   'system.mes.material.getPropertyValue('01JRDP4APW-5D56ZQ8C-8949XKYT')'
system.mes.material.getPropertyValuesForMaterial | incorrect | XXS | Code Examples: code   typo | change   'system.mes.material.getPropertyValueFor('IRB/5391537510212')' to   'system.mes.material.getPropertyValuesForMaterial('IRB/5391537510212')'
system.mes.material.deletePropertyValuesFor | incorrect | XXS | Code Examples: code   typo | change   'system.mes.material.deletePropertyValueFor('IRB/5391537510212', ['Density',   'Melting Point'])' to   'system.mes.material.deletePropertyValuesFor('IRB/5391537510212', ['Density',   'Melting Point'])'
system.mes.material.newMaterialReasonCode | incorrect | XXS | Code Examples: code   missing line | need to make   'requireComments' not null to save. Simple to just add the line.
system.mes.material.saveMaterialReasonCode | incorrect | XXS | Code Examples: code   missing line | need to make   'requireComments' not null to save. Simple to just add the line.
system.mes.productionOrder.newProductionOrder | incorrect | XXS | Returns: row =   quantity, quantityProduced, quantityScheduled | the default value   column for these 3 rows should be "0.0", not "0"
system.mes.productionOrder.getProductionOrder | incorrect | XXS | JavaDoc | javadoc should say   "Retrieves a production order by its ID or name." and "@param idOrName the ID or name of the production order to   retrieve"
system.mes.schedule.findSchedules | inconsistent | XXS | Returns: columns in   the wrong order | the columns should be   in the order, "Name, Type, Description", not "Type, Name,   Description"
system.mes.unitOfMeasure.findUnitsOfMeasure | incorrect | XS | Code Examples | in line 23,   "findUnitOfMeasure" should be changed to   "findUnitsOfMeasure"
system.mes.unitOfMeasure.saveUnitOfMeasureConversion | incorrect | XS | Code Examples | in line 1,   "new_uom" should be changed to "new_uomc"
system.mes.unitOfMeasure.doesConversionExist | incorrect | XS | Code Examples | should be calling   doesConversionExist, not doesUnitOfMeasureExist. Also change 'Kg' to   'Kilogram' because it is supposed to take in names, not symbols.
system.mes.unitOfMeasure.getConversionFor | incorrect | XS | Code Examples | should be calling   getConversionFor, not getUnitOfMeasureConversion. Also change 'Kg' to   'Kilogram' because it is supposed to take in names, not symbols.