### PR TITLE
data model uom field detail sentence removal

### DIFF
--- a/docs/appendix/data-model/equipment-model/equipment-property.md
+++ b/docs/appendix/data-model/equipment-model/equipment-property.md
@@ -77,8 +77,6 @@ configurations.
 References the unit of measure applicable to this property, such as kilograms or liters, supporting context for values as well as conversions.
 See [unit_of_measure](../utility-models/unit-of-measure-model/unit-of-measure) for details.
 
-This is for display purposes only and is not a reference to any [unit_of_measure](../utility-models/unit-of-measure-model/unit-of-measure) entity.
-
 ### `equipment_class_id`
 
 References the `EquipmentClass` that this property applies to. This relationship allows the property to be defined at

--- a/docs/appendix/data-model/location-model/location-property.md
+++ b/docs/appendix/data-model/location-model/location-property.md
@@ -74,5 +74,3 @@ configurations.
 
 References the unit of measure applicable to this property, such as kilograms or liters, supporting context for values as well as conversions.
 See [unit_of_measure](../utility-models/unit-of-measure-model/unit-of-measure) for details.
-
-This is for display purposes only and is not a reference to any [unit_of_measure](../utility-models/unit-of-measure-model/unit-of-measure) entity.

--- a/docs/appendix/data-model/material-model/material-property.md
+++ b/docs/appendix/data-model/material-model/material-property.md
@@ -85,8 +85,6 @@ Indicates if the property value is required or can be left empty (`null`).
 References the unit of measure applicable to this property, such as kilograms or liters, supporting context for values as well as conversions.
 See [unit_of_measure](../utility-models/unit-of-measure-model/unit-of-measure) for details.
 
-This is for display purposes only and is not a reference to any [unit_of_measure](../utility-models/unit-of-measure-model/unit-of-measure) entity.
-
 ### `material_class_id`
 
 References the `MaterialClass` entity associated with this property, ensuring that each material within the class can

--- a/docs/appendix/data-model/production-order-model/production-order-property.md
+++ b/docs/appendix/data-model/production-order-model/production-order-property.md
@@ -74,5 +74,3 @@ configurations.
 
 References the unit of measure applicable to this property, such as kilograms or liters, supporting context for values as well as conversions.
 See [unit_of_measure](../utility-models/unit-of-measure-model/unit-of-measure) for details.
-
-This is for display purposes only and is not a reference to any [unit_of_measure](../utility-models/unit-of-measure-model/unit-of-measure) entity.


### PR DESCRIPTION
closes [#1292](https://github.com/TamakiControl/tamaki-mes/issues/1292)

Removed the sentence, "This is for display purposes only and is not a reference to any unit_of_measure entity."