### PR TITLE
fixed up uom conversion code examples

### DIFF
--- a/docs/appendix/script-api/unit-of-measure-script-api/new-unit-of-measure-conversion.md
+++ b/docs/appendix/script-api/unit-of-measure-script-api/new-unit-of-measure-conversion.md
@@ -48,7 +48,7 @@ new_uomc = system.mes.unitOfMeasure.newUnitOfMeasureConversion()
 
 # Set basic attributes for the new unit of measure
 new_uomc['toId'] = '01JCH3T85P-KVCB8ZR5-0B83A3SX'
-new_uomc['conversionFactor'] = '0.33'
+new_uomc['conversionFactor'] = 0.33
 new_uomc['fromId'] = '01JCH4NB3J-BTERAZ27-QEQQN4ME'
 # (You can continue setting other properties as needed here)
 

--- a/docs/appendix/script-api/unit-of-measure-script-api/save-unit-of-measure-conversion.md
+++ b/docs/appendix/script-api/unit-of-measure-script-api/save-unit-of-measure-conversion.md
@@ -41,9 +41,9 @@ Returns a JSON representation of the saved unit of measure conversion.
 # Generate the object structure for a new unit of measure conversion object, set the parameters and save it
 new_uomc = system.mes.unitOfMeasure.newUnitOfMeasureConversion()
 new_uomc['toId'] = '01JCH3T85P-KVCB8ZR5-0B83A3SX'
-new_uomc['conversionFactor'] = '0.33'
+new_uomc['conversionFactor'] = 0.33
 new_uomc['fromId'] = '01JCH4NB3J-BTERAZ27-QEQQN4ME'
-saved_uomc = system.mes.unitOfMeasure.saveUnitOfMeasureConversion(**new_uom)
+saved_uomc = system.mes.unitOfMeasure.saveUnitOfMeasureConversion(**new_uomc)
 
 # Output the JSON representation of the saved unit of measure conversion
 print(saved_uomc)
@@ -53,7 +53,7 @@ uomc_data = system.mes.unitOfMeasure.newUnitOfMeasureConversion()
 
 # Set basic attributes for the updated unit of measure conversion
 uomc_data['toId'] = '01JCH3T85P-KVCB8ZR5-0B83A3SX'
-uomc_data['conversionFactor'] = '0.33'
+uomc_data['conversionFactor'] = 0.33
 uomc_data['fromId'] = '01JCH4NB3J-BTERAZ27-QEQQN4ME'
 uomc_data['notes'] = 'Conversion from L to BT'
 # (You can continue setting other properties as needed here)


### PR DESCRIPTION
closed [#1339](https://github.com/TamakiControl/tamaki-mes/issues/1339) [#1340](https://github.com/TamakiControl/tamaki-mes/issues/1340)

Fixed typo in save-unit-of-measure-conversion.md code example (replaced "**new_uom" with "new_uomc").

Changed the lines setting conversionFactor in new-unit-of-measure-conversion.md and save-unit-of-measure-conversion.md code example sections to not use strings for better clarity.