### PR TITLE
added findMaterialReasonCodes documentation

### DIFF
--- a/docs/appendix/script-api/material-script-api/delete-material-reason-code.md
+++ b/docs/appendix/script-api/material-script-api/delete-material-reason-code.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 59
+sidebar_position: 60
 title: "deleteMaterialReasonCode"
 description: "Deletes the material reason code with the given ID."
 ---

--- a/docs/appendix/script-api/material-script-api/find-material-reason-codes.md
+++ b/docs/appendix/script-api/material-script-api/find-material-reason-codes.md
@@ -1,0 +1,78 @@
+---
+sidebar_position: 58
+title: "findMaterialReasonCodes"
+description: "Retrieves material reason codes based on the specified pagination, sort, and column constraint parameters."
+---
+
+# system.mes.material.findMaterialReasonCodes
+
+## Description
+
+Retrieves [Material Reason Codes](../../data-model/material-model/material-reason-code) records based on the specified pagination, sort, and column constraint parameters.
+
+## Syntax
+
+```python
+system.mes.material.findMaterialReasonCodes(**queryRequest)
+```
+
+## Parameters
+
+Using Python keyword arguments, a [Query Request](../query-script-api/new-query-request) can be passed to the `findMaterialReasonCodes` function
+without specifying each parameter individually. Please refer to the [Query Request](../query-script-api/new-query-request) documentation for a list of parameters.
+
+| Parameter      | Type            | Nullable | Description                                                                                                                                                                                                                                                                                                         |
+|----------------|-----------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `queryRequest` | `Query Request` | False    | Using Python keyword arguments, a [Query Request](../query-script-api/new-query-request) can be passed to the `findMaterialReasonCodes` function without specifying each parameter individually. Please refer to the [Query Request](../query-script-api/new-query-request) documentation for a list of parameters. |
+
+
+## Returns
+
+Returns a Query Result object with the following properties:
+
+| Name            | Type                                                                                       | Description                                                                                                      |
+|-----------------|--------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| `content`       | `List`&lt;[Material Reason Code](../../data-model/material-model/material-reason-code)&gt; | The list of all records found that meet the specified criteria                                                   |
+| `totalPages`    | `Integer`                                                                                  | If pagination is used, this is the number of total pages of records in the database for the specified page size. |
+| `totalElements` | `Long`                                                                                     | If pagination is used, this is the number of records in the database that meet the specified criteria.           |
+| `pageSize`      | `Integer`                                                                                  | If pagination is used, this is the specified page size.                                                          |
+| `pageIndex`     | `Integer`                                                                                  | If pagination is used, this is the specified page index.                                                         |
+| `hasContent`    | `Boolean`                                                                                  | True if any records were found that meet the specified criteria.                                                 |
+| `isFirst`       | `Boolean`                                                                                  | If pagination is used, this is true if the first page was returned.                                              |
+| `isLast`        | `Boolean`                                                                                  | If pagination is used, this is true if the last page was returned.                                               |
+| `hasNext`       | `Boolean`                                                                                  | If pagination is used, this is true if there is a page of content available after this one.                      |
+| `hasPrevious`   | `Boolean`                                                                                  | If pagination is used, this is true if there is a page of content available before this one.                     |
+
+## Code Examples
+
+Here is an example of how to use a Query Request to retrieve the first ten material reason codes created in 2025 sorted by their
+reason code.
+
+```python
+# Generate the object structure for a new query request
+queryRequest = system.mes.query.newQueryRequest()
+
+# Set the basic attributes of the query request
+queryRequest['pageSize'] = 10
+queryRequest['pageIndex'] = 0
+
+queryRequest['sortFields'] = ['reasonCode']
+queryRequest['sortDirections'] = ['Ascending']
+
+# Generate the object structure for a filter for the query request
+filterRequest = system.mes.query.newFilterRequest()
+filterRequest['field'] = 'createdDate'
+filterRequest['condition'] = 'between'
+filterRequest['minDateValue'] = '2025-01-01T00:00:00Z'
+filterRequest['maxDateValue'] = '2026-01-01T00:00:00Z'
+
+filters = [filterRequest]
+
+queryRequest['filters'] = filters
+
+# Retrieve the material reason codes that match the filter
+result = system.mes.material.findMaterialReasonCodes(**queryRequest)
+
+# Output the material reason codes that match the filter.
+print(result)
+```

--- a/docs/appendix/script-api/material-script-api/intro.md
+++ b/docs/appendix/script-api/material-script-api/intro.md
@@ -213,6 +213,10 @@ Retrieves a [Material Reason Codes](../../data-model/material-model/material-rea
 
 Retrieves a list of all [Material Reason Codes](../../data-model/material-model/material-reason-code) records in the system. Returns a list of JSON objects representing all material reason codes.
 
+### [`findMaterialReasonCodes`](./find-material-reason-codes)
+
+Retrieves [Material Reason Codes](../../data-model/material-model/material-reason-code) records based on the specified pagination, sort, and column constraint parameters. Returns a Query Result object.
+
 ### [`validateMaterialReasonCode`](./validate-material-reason-code)
 
 Validates the specified parameters for a [Material Reason Codes](../../data-model/material-model/material-reason-code) record and returns any validation errors.

--- a/docs/appendix/script-api/material-script-api/validate-material-reason-code.md
+++ b/docs/appendix/script-api/material-script-api/validate-material-reason-code.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 58
+sidebar_position: 59
 title: "validateMaterialReasonCode"
 description: "Validates the specified parameters for a material reason code."
 ---


### PR DESCRIPTION
closes [1529](https://github.com/TamakiControl/tamaki-mes/issues/1529)

This pull request updates the documentation for the Material Reason Code script API. The most significant change is the addition of a new API function, `findMaterialReasonCodes`, which allows users to retrieve material reason codes with advanced query options. The sidebar positions for related documentation files have also been updated to accommodate this new addition.

#### New API Documentation

* Added documentation for the new `findMaterialReasonCodes` function, including its syntax, parameters, return values, and usage examples in `find-material-reason-codes.md`. This function supports pagination, sorting, and filtering of material reason codes.
* Updated the API introduction in `intro.md` to reference the new `findMaterialReasonCodes` function and describe its capabilities.

#### Documentation Organization

* Updated the sidebar position for `validate-material-reason-code.md` to maintain logical ordering after the addition of the new API documentation.
* Updated the sidebar position for `delete-material-reason-code.md` to reflect the new documentation structure.