### PR TITLE
Updated docs to match new time standard

### DIFF
--- a/docs/appendix/script-api/inventory-operation-script-api/execute-inventory-operation.md
+++ b/docs/appendix/script-api/inventory-operation-script-api/execute-inventory-operation.md
@@ -27,8 +27,8 @@ system.mes.inventory.operation.executeInventoryOperation(inventoryOperationId, p
 | `secondaryLotIdOrName` | `String`        | True     | The ID or name of the secondary lot to start.                           |
 | `materialIdOrPath`     | `String`        | True     | The ID or path of the material associated with the inventory operation. |
 | `inventoryName`        | `String`        | True     | The name of the inventory associated with the inventory operation.      |
-| `startDate`            | `Instant`       | True     | The start date of the inventory operation.                              |
-| `endDate`              | `Instant`       | True     | The end date of the inventory operation.                                |
+| `startDateMillis`      | `Long`          | True     | The start date of the inventory operation.                              |
+| `endDateMillis`        | `Long`          | True     | The end date of the inventory operation.                                |
 
 ## Returns
 

--- a/docs/appendix/script-api/inventory-operation-script-api/start-inventory-operation.md
+++ b/docs/appendix/script-api/inventory-operation-script-api/start-inventory-operation.md
@@ -25,7 +25,7 @@ system.mes.inventory.operation.startInventoryOperation(inventoryOperationId, pri
 | `secondaryLotIdOrName` | `String`        | True     | The ID or name of the secondary lot to start.                           |
 | `materialIdOrPath`     | `String`        | True     | The ID or path of the material associated with the inventory operation. |
 | `inventoryName`        | `String`        | True     | The name of the inventory associated with the inventory operation.      |
-| `startDate`            | `Instant`       | True     | The start date of the inventory operation.                              |
+| `startDateMillis`      | `Long`          | True     | The start date of the inventory operation.                              |
 
 ## Returns
 

--- a/docs/appendix/script-api/inventory-operation-script-api/stop-inventory-operation.md
+++ b/docs/appendix/script-api/inventory-operation-script-api/stop-inventory-operation.md
@@ -23,7 +23,7 @@ system.mes.inventory.operation.stopInventoryOperation(inventoryOperationId, quan
 | `inventoryOperationId` | `String` (ULID) | False    | The ID of the inventory operation to end.                          |
 | `quantity`             | `Double`        | False    | The quantity that the inventory operation processed.               |
 | `inventoryName`        | `String`        | True     | The name of the inventory associated with the inventory operation. |
-| `endDate`              | `Instant`       | True     | The end date of the inventory operation.                           |
+| `endDateMillis`        | `Long`          | True     | The end date of the inventory operation.                           |
 
 ## Returns
 


### PR DESCRIPTION
closes [#1633](https://github.com/TamakiControl/tamaki-mes/issues/1633)

This pull request updates the documentation for the inventory operation script API to clarify the expected format for date parameters. The main change is that date fields previously described as `Instant` are now specified as millisecond timestamps (`Long`), which improves clarity for API consumers.

**Inventory operation date parameter updates:**

* Changed `startDate` and `endDate` parameters to `startDateMillis` and `endDateMillis` with type `Long` in `executeInventoryOperation` documentation, replacing `Instant`.
* Changed `startDate` parameter to `startDateMillis` with type `Long` in `startInventoryOperation` documentation, replacing `Instant`.
* Changed `endDate` parameter to `endDateMillis` with type `Long` in `stopInventoryOperation` documentation, replacing `Instant`.