### PR TITLE
Created dashboard API and Data Model docs.

### DIFF
--- a/docs/appendix/data-model/dashboard-model/_category_.json
+++ b/docs/appendix/data-model/dashboard-model/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Dashboard Model",
+  "position": 10,
+  "link": {
+    "type": "doc",
+    "id": "appendix/data-model/dashboard-model/intro"
+  }
+}
+

--- a/docs/appendix/data-model/dashboard-model/dashboard-widget-parameter-type.md
+++ b/docs/appendix/data-model/dashboard-model/dashboard-widget-parameter-type.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 5
+title: "dashboard_widget_parameter_types"
+description: "Documentation for the dashboard_widget_parameter_types table, outlining its columns and structure."
+---
+
+# Dashboard Widget Parameter Type
+
+## Overview
+
+Represents a type of parameter a widget can accept. Each type points to a Perspective view used to edit its value.
+
+## Table Structure
+
+The following table outlines the SQL columns for the `dashboard_widget_parameter_types` table, providing a brief
+description of each, along with sample data where applicable.
+
+| Column          | Type            | Description                                                                       | Example                        |
+|-----------------|-----------------|-----------------------------------------------------------------------------------|--------------------------------|
+| `id`            | `String` (ULID) | Unique identifier for the entity.                                                 | `01JAP8RJBN-8ZTPXSGY-J9GSDPE1` |
+| `enabled`       | `Boolean`       | If the entity is enabled or not.                                                  | `true`                         |
+| `created_date`  | `DateTime`      | Date the entity was created.                                                      | `2025-01-01T10:00:00Z`         |
+| `created_by`    | `String`        | Person who created the entity.                                                    | `TamakiMES`                    |
+| `modified_date` | `DateTime`      | Date the entity was modified. Value is null upon creation, and on first edit.     | `2025-01-02T12:00:00Z`         |
+| `modified_by`   | `String`        | Last person to modify the entity. Value is null upon creation, and on first edit. | `TamakiMES`                    |
+| `notes`         | `String`        | Notes about the entity.                                                           | `Used by dropdown editors`     |
+| `spare1`        | `String`        | The first spare column for additional context.                                    | `extra context 1`              |
+| `spare2`        | `String`        | The second spare column for additional context.                                   | `extra context 2`              |
+| `spare3`        | `String`        | The third spare column for additional context.                                    | `extra context 3`              |
+| `name`          | `String`        | Unique name of the parameter type.                                                | `Integer`                      |
+| `view_path`     | `String`        | Perspective view path used to edit this type of parameter.                        | `Mes/Editors/Integer`          |
+
+## Field Details
+
+### `view_path`
+
+Perspective View path used by the UI to edit parameter values of this type.
+

--- a/docs/appendix/data-model/dashboard-model/dashboard-widget-parameter.md
+++ b/docs/appendix/data-model/dashboard-model/dashboard-widget-parameter.md
@@ -1,0 +1,49 @@
+---
+sidebar_position: 4
+title: "dashboard_widget_parameters"
+description: "Documentation for the dashboard_widget_parameters table, outlining its columns and structure."
+---
+
+# Dashboard Widget Parameter
+
+## Overview
+
+Represents a single configurable parameter for a widget template, including its label, key used by the Ignition View,
+default value JSON, and editor configuration JSON.
+
+## Table Structure
+
+The following table outlines the SQL columns for the `dashboard_widget_parameters` table, providing a brief description
+of each, along with sample data where applicable.
+
+| Column               | Type            | Description                                                                                                  | Example                        |
+|----------------------|-----------------|--------------------------------------------------------------------------------------------------------------|--------------------------------|
+| `id`                 | `String` (ULID) | Unique identifier for the entity.                                                                            | `01JAP8RJBN-8ZTPXSGY-J9GSDPE1` |
+| `enabled`            | `Boolean`       | If the entity is enabled or not.                                                                             | `true`                         |
+| `created_date`       | `DateTime`      | Date the entity was created.                                                                                 | `2025-01-01T10:00:00Z`         |
+| `created_by`         | `String`        | Person who created the entity.                                                                               | `TamakiMES`                    |
+| `modified_date`      | `DateTime`      | Date the entity was modified. Value is null upon creation, and gets initially populated upon first edit.     | `2025-01-02T12:00:00Z`         |
+| `modified_by`        | `String`        | Last person to modify the entity. Value is null upon creation, and gets initially populated upon first edit. | `TamakiMES`                    |
+| `notes`              | `String`        | Notes about the entity.                                                                                      | `Default is empty`             |
+| `spare1`             | `String`        | The first spare column that can be used for additional context on the entity.                                | `extra context 1`              |
+| `spare2`             | `String`        | The second spare column that can be used for additional context on the entity.                               | `extra context 2`              |
+| `spare3`             | `String`        | The third spare column that can be used for additional context on the entity.                                | `extra context 3`              |
+| `widget_id`          | `String` (ULID) | Reference to the dashboard widget this parameter belongs to.                                                 | `01JAP8RJBN-8ZTPXSGY-J9GSDPE1` |
+| `parameter_type_id`  | `String` (ULID) | Reference to the parameter type that controls how this parameter is edited.                                  | `01JAP8RJBN-8ZTPXSGY-J9GSDPE1` |
+| `name`               | `String`        | Display label for this parameter in the configuration UI.                                                    | `Chart Title`                  |
+| `description`        | `String`        | Description of what the parameter controls.                                                                  | `Title shown at top of chart`  |
+| `parameter_key`      | `String`        | The key used in the widget's view params object (actual parameter name in the view).                         | `title`                        |
+| `default_value_json` | `String`        | JSON representing the default value for this parameter.                                                      | `"\"My Chart\""`               |
+| `editor_config_json` | `String`        | JSON configuring the parameter editor (e.g., dropdown options, ranges).                                      | `{ "min": 0, "max": 100 }`     |
+| `sort_order`         | `Integer`       | Display sort order of the parameter within the widget configuration UI.                                      | `0`                            |
+
+## Field Details
+
+### `parameter_key`
+
+Actual parameter name expected by the widget view.
+
+### `default_value_json` and `editor_config_json`
+
+JSON strings used to provide initial value and editor configuration.
+

--- a/docs/appendix/data-model/dashboard-model/dashboard-widget.md
+++ b/docs/appendix/data-model/dashboard-model/dashboard-widget.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 3
+title: "dashboard_widgets"
+description: "Documentation for the dashboard_widgets table, outlining its columns and structure."
+---
+
+# Dashboard Widget
+
+## Overview
+
+Represents a reusable widget template that can be added to dashboards. Defines the widget identity, the Ignition View to
+render, and sizing constraints.
+
+## Table Structure
+
+The following table outlines the SQL columns for the `dashboard_widgets` table, providing a brief description of each,
+along with sample data where applicable.
+
+| Column           | Type            | Description                                                                                                  | Example                        |
+|------------------|-----------------|--------------------------------------------------------------------------------------------------------------|--------------------------------|
+| `id`             | `String` (ULID) | Unique identifier for the entity.                                                                            | `01JAP8RJBN-8ZTPXSGY-J9GSDPE1` |
+| `enabled`        | `Boolean`       | If the entity is enabled or not.                                                                             | `true`                         |
+| `created_date`   | `DateTime`      | Date the entity was created.                                                                                 | `2025-01-01T10:00:00Z`         |
+| `created_by`     | `String`        | Person who created the entity.                                                                               | `TamakiMES`                    |
+| `modified_date`  | `DateTime`      | Date the entity was modified. Value is null upon creation, and gets initially populated upon first edit.     | `2025-01-02T12:00:00Z`         |
+| `modified_by`    | `String`        | Last person to modify the entity. Value is null upon creation, and gets initially populated upon first edit. | `TamakiMES`                    |
+| `notes`          | `String`        | Notes about the entity.                                                                                      | `Common widget for OEE views`  |
+| `spare1`         | `String`        | The first spare column that can be used for additional context on the entity.                                | `extra context 1`              |
+| `spare2`         | `String`        | The second spare column that can be used for additional context on the entity.                               | `extra context 2`              |
+| `spare3`         | `String`        | The third spare column that can be used for additional context on the entity.                                | `extra context 3`              |
+| `name`           | `String`        | User-friendly name of the widget.                                                                            | `Time Series Chart`            |
+| `category`       | `String`        | Category of the widget.                                                                                      | `OEE`                          |
+| `description`    | `String`        | Description of the widget functionality.                                                                     | `Displays KPI trend over time` |
+| `view_path`      | `String`        | Path to the Ignition View that renders the widget.                                                           | `Mes/Widgets/TimeSeries`       |
+| `icon_path`      | `String`        | Path to an icon for the widget.                                                                              | `material/trending_up`         |
+| `default_width`  | `Integer`       | Default grid width of the widget.                                                                            | `2`                            |
+| `default_height` | `Integer`       | Default grid height of the widget.                                                                           | `2`                            |
+| `min_width`      | `Integer`       | Minimum grid width allowed.                                                                                  | `2`                            |
+| `min_height`     | `Integer`       | Minimum grid height allowed.                                                                                 | `2`                            |
+
+## Field Details
+
+### `view_path`
+
+Perspective View path that implements the widget’s UI.
+
+### `default_width` and `default_height`
+
+Default size (in grid columns/rows) to use when placing the widget on a dashboard.
+
+### `min_width` and `min_height`
+
+Minimum allowed size to preserve widget usability.
+

--- a/docs/appendix/data-model/dashboard-model/dashboard.md
+++ b/docs/appendix/data-model/dashboard-model/dashboard.md
@@ -1,0 +1,57 @@
+---
+sidebar_position: 2
+title: "dashboards"
+description: "Documentation for the dashboards table, outlining its columns and structure."
+---
+
+# Dashboard
+
+## Overview
+
+Represents a saved dashboard configuration, including layout mode, grid settings, and the serialized instances
+definition used by the UI.
+
+## Table Structure
+
+The following table outlines the SQL columns for the `dashboards` table, providing a brief description of each, along
+with sample data where applicable.
+
+| Column               | Type            | Description                                                                                                  | Example                        |
+|----------------------|-----------------|--------------------------------------------------------------------------------------------------------------|--------------------------------|
+| `id`                 | `String` (ULID) | Unique identifier for the entity.                                                                            | `01JAP8RJBN-8ZTPXSGY-J9GSDPE1` |
+| `enabled`            | `Boolean`       | If the entity is enabled or not.                                                                             | `true`                         |
+| `created_date`       | `DateTime`      | Date the entity was created.                                                                                 | `2025-01-01T10:00:00Z`         |
+| `created_by`         | `String`        | Person who created the entity.                                                                               | `TamakiMES`                    |
+| `modified_date`      | `DateTime`      | Date the entity was modified. Value is null upon creation, and gets initially populated upon first edit.     | `2025-01-02T12:00:00Z`         |
+| `modified_by`        | `String`        | Last person to modify the entity. Value is null upon creation, and gets initially populated upon first edit. | `TamakiMES`                    |
+| `notes`              | `String`        | Notes about the entity.                                                                                      | `Pinned to production team`    |
+| `spare1`             | `String`        | The first spare column that can be used for additional context on the entity.                                | `extra context 1`              |
+| `spare2`             | `String`        | The second spare column that can be used for additional context on the entity.                               | `extra context 2`              |
+| `spare3`             | `String`        | The third spare column that can be used for additional context on the entity.                                | `extra context 3`              |
+| `name`               | `String`        | User-friendly name for the dashboard.                                                                        | `Production Overview`          |
+| `url`                | `String`        | URL-friendly version of the name used for routing.                                                           | `production-overview`          |
+| `is_public`          | `Boolean`       | True if the dashboard is public (no username).                                                               | `false`                        |
+| `username`           | `String`        | Ignition username of the dashboard owner; null if public.                                                    | `operator01`                   |
+| `icon_path`          | `String`        | Path to a UI icon for the dashboard.                                                                         | `material/dashboard`           |
+| `pack`               | `Boolean`       | When true, auto-sizes to fit content (vs fixed grid).                                                        | `true`                         |
+| `grid`               | `String` (Enum) | Grid layout mode for the dashboard.                                                                          | `STRETCH`                      |
+| `row_count`          | `Integer`       | Number of rows in the dashboard grid (fixed layout).                                                         | `10`                           |
+| `column_count`       | `Integer`       | Number of columns in the dashboard grid (fixed layout).                                                      | `10`                           |
+| `row_gutter_size`    | `Integer`       | Vertical spacing (pixels) between rows (fixed layout).                                                       | `6`                            |
+| `column_gutter_size` | `Integer`       | Horizontal spacing (pixels) between columns (fixed layout).                                                  | `6`                            |
+| `instances_json`     | `String`        | JSON for the Perspective dashboard component `props.instances`.                                              | `[{...}]`                      |
+
+## Field Details
+
+### `grid`
+
+Determines how embedded views/components are laid out. Example: `STRETCH`.
+
+### `pack`
+
+When true, the dashboard adapts to its content rather than using a fixed grid.
+
+### `instances_json`
+
+Serialized JSON of the dashboard instances array used by the Perspective component.
+

--- a/docs/appendix/data-model/dashboard-model/intro.md
+++ b/docs/appendix/data-model/dashboard-model/intro.md
@@ -1,0 +1,20 @@
+---
+sidebar_position: 1
+title: "Dashboard Model Overview"
+description: "Overview of the Dashboard data model and its primary entities."
+---
+
+# Dashboard Model
+
+The Dashboard model defines entities used to configure, store, and render user dashboards and their widget templates.
+It includes support for widget parameterization and editor configuration.
+
+This model consists of the following primary entities:
+
+- Dashboard
+- DashboardWidget
+- DashboardWidgetParameter
+- DashboardWidgetParameterType
+
+Each entity follows the common TamakiMES base fields for auditing and metadata.
+

--- a/docs/appendix/data-model/intro.md
+++ b/docs/appendix/data-model/intro.md
@@ -80,6 +80,12 @@ key entities involved in manufacturing operations, supporting functions like **O
 
    The performance data helps in evaluating and improving the efficiency of operations and scheduling.
 
+10. **Dashboard**  
+   Defines configurable user dashboards and widget templates used for displaying KPIs and production context:
+   - **Dashboards**: Saved layouts, grid settings, and serialized instances for the UI.
+   - **Widgets**: Reusable templates that render Perspective views with sizing constraints.
+   - **Widget Parameters/Types**: Parameter metadata, default values, and editor configuration views.
+
 ---
 
 Each module plays a specific role in the overall MES framework, enabling **TamakiMES** to provide comprehensive,

--- a/docs/appendix/script-api/dashboard-script-api/_category_.json
+++ b/docs/appendix/script-api/dashboard-script-api/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "system.mes.dashboard",
+  "position": 2,
+  "link": {
+    "type": "doc",
+    "id": "appendix/script-api/dashboard-script-api/intro"
+  }
+}
+

--- a/docs/appendix/script-api/dashboard-script-api/delete-dashboard.md
+++ b/docs/appendix/script-api/dashboard-script-api/delete-dashboard.md
@@ -1,0 +1,41 @@
+---
+sidebar_position: 31
+title: "deleteDashboard"
+description: "Deletes a dashboard by ID."
+---
+
+# system.mes.dashboard.deleteDashboard
+
+## Description
+
+Deletes a Dashboard by its ID.
+
+## Syntax
+
+```python
+system.mes.dashboard.deleteDashboard(id)
+```
+
+## Parameters
+
+| Parameter | Type            | Nullable | Description                        |
+|-----------|-----------------|----------|------------------------------------|
+| `id`      | `String` (ULID) | False    | The ID of the dashboard to delete. |
+
+## Returns
+
+If successful, an ApiResponse Object is returned with the success bool set True. If unsuccessful, an exception may be
+thrown.
+
+| Name      | Type      | Description                                                 |
+|-----------|-----------|-------------------------------------------------------------|
+| `success` | `Boolean` | Indicates if the delete was successful.                     |
+| `message` | `String`  | The reason why the deletion was successful or unsuccessful. |
+| `data`    | `String`  | The data associated with the deletion.                      |
+| `error`   | `String`  | The errors associated with the deletion.                    |
+
+## Code Examples
+
+```python
+system.mes.dashboard.deleteDashboard('01JAP8RJBN-8ZTPXSGY-J9GSDPE1')
+```

--- a/docs/appendix/script-api/dashboard-script-api/delete-parameter-type.md
+++ b/docs/appendix/script-api/dashboard-script-api/delete-parameter-type.md
@@ -1,0 +1,41 @@
+---
+sidebar_position: 8
+title: "deleteParameterType"
+description: "Deletes a dashboard widget parameter type by ID."
+---
+
+# system.mes.dashboard.deleteParameterType
+
+## Description
+
+Deletes a Dashboard Widget Parameter Type by its ID.
+
+## Syntax
+
+```python
+system.mes.dashboard.deleteParameterType(id)
+```
+
+## Parameters
+
+| Parameter | Type            | Nullable | Description                             |
+|-----------|-----------------|----------|-----------------------------------------|
+| `id`      | `String` (ULID) | False    | The ID of the parameter type to delete. |
+
+## Returns
+
+If successful, an ApiResponse Object is returned with the success bool set True. If unsuccessful, an exception may be
+thrown.
+
+| Name      | Type      | Description                                                 |
+|-----------|-----------|-------------------------------------------------------------|
+| `success` | `Boolean` | Indicates if the delete was successful.                     |
+| `message` | `String`  | The reason why the deletion was successful or unsuccessful. |
+| `data`    | `String`  | The data associated with the deletion.                      |
+| `error`   | `String`  | The errors associated with the deletion.                    |
+
+## Code Examples
+
+```python
+system.mes.dashboard.deleteParameterType('01JAP8RJBN-8ZTPXSGY-J9GSDPE1')
+```

--- a/docs/appendix/script-api/dashboard-script-api/delete-widget-parameter.md
+++ b/docs/appendix/script-api/dashboard-script-api/delete-widget-parameter.md
@@ -1,0 +1,41 @@
+---
+sidebar_position: 23
+title: "deleteWidgetParameter"
+description: "Deletes a dashboard widget parameter by ID."
+---
+
+# system.mes.dashboard.deleteWidgetParameter
+
+## Description
+
+Deletes a Dashboard Widget Parameter by its ID.
+
+## Syntax
+
+```python
+system.mes.dashboard.deleteWidgetParameter(parameterId)
+```
+
+## Parameters
+
+| Parameter     | Type            | Nullable | Description                               |
+|---------------|-----------------|----------|-------------------------------------------|
+| `parameterId` | `String` (ULID) | False    | The ID of the widget parameter to delete. |
+
+## Returns
+
+If successful, an ApiResponse Object is returned with the success bool set True. If unsuccessful, an exception may be
+thrown.
+
+| Name      | Type      | Description                                                 |
+|-----------|-----------|-------------------------------------------------------------|
+| `success` | `Boolean` | Indicates if the delete was successful.                     |
+| `message` | `String`  | The reason why the deletion was successful or unsuccessful. |
+| `data`    | `String`  | The data associated with the deletion.                      |
+| `error`   | `String`  | The errors associated with the deletion.                    |
+
+## Code Examples
+
+```python
+system.mes.dashboard.deleteWidgetParameter('01JAP8RJBN-8ZTPXSGY-J9GSDPE1')
+```

--- a/docs/appendix/script-api/dashboard-script-api/delete-widget.md
+++ b/docs/appendix/script-api/dashboard-script-api/delete-widget.md
@@ -1,0 +1,41 @@
+---
+sidebar_position: 17
+title: "deleteWidget"
+description: "Deletes a dashboard widget by ID."
+---
+
+# system.mes.dashboard.deleteWidget
+
+## Description
+
+Deletes a Dashboard Widget by its ID.
+
+## Syntax
+
+```python
+system.mes.dashboard.deleteWidget(id)
+```
+
+## Parameters
+
+| Parameter | Type            | Nullable | Description                     |
+|-----------|-----------------|----------|---------------------------------|
+| `id`      | `String` (ULID) | False    | The ID of the widget to delete. |
+
+## Returns
+
+If successful, an ApiResponse Object is returned with the success bool set True. If unsuccessful, an exception may be
+thrown.
+
+| Name      | Type      | Description                                                 |
+|-----------|-----------|-------------------------------------------------------------|
+| `success` | `Boolean` | Indicates if the delete was successful.                     |
+| `message` | `String`  | The reason why the deletion was successful or unsuccessful. |
+| `data`    | `String`  | The data associated with the deletion.                      |
+| `error`   | `String`  | The errors associated with the deletion.                    |
+
+## Code Examples
+
+```python
+system.mes.dashboard.deleteWidget('01JAP8RJBN-8ZTPXSGY-J9GSDPE1')
+```

--- a/docs/appendix/script-api/dashboard-script-api/export-widgets-as-csv.md
+++ b/docs/appendix/script-api/dashboard-script-api/export-widgets-as-csv.md
@@ -1,0 +1,53 @@
+---
+sidebar_position: 34
+title: "exportWidgetsAsCsv"
+description: "Exports dashboard widgets as raw bytes in CSV format (UTF-8 encoded)."
+---
+
+# system.mes.dashboard.exportWidgetsAsCsv
+
+## Description
+
+Exports dashboard widgets as raw bytes in CSV format (UTF-8 encoded). Use the no-argument form to export all widgets, or
+pass a list of widget IDs or names to export only those selected widgets.
+
+## Syntax
+
+```python
+system.mes.dashboard.exportWidgetsAsCsv()
+system.mes.dashboard.exportWidgetsAsCsv(idsOrNames)
+```
+
+## Parameters
+
+### Method 1: No Parameters (Export All Widgets)
+
+| Parameter | Type | Nullable | Description                               |
+|-----------|------|----------|-------------------------------------------|
+| None      | -    | -        | This method does not take any parameters. |
+
+### Method 2: Export Selected Widgets by ID or Name
+
+| Parameter    | Type           | Nullable | Description                              |
+|--------------|----------------|----------|------------------------------------------|
+| `idsOrNames` | `List<String>` | False    | A list of widget IDs or names to export. |
+
+## Returns
+
+A Byte array (Byte[]) containing the raw CSV bytes of the exported widgets.
+
+## Code Examples
+
+### Perspective: Export All Widgets
+
+```python
+csvBytes = system.mes.dashboard.exportWidgetsAsCsv()
+system.perspective.download("widgets.csv", csvBytes)
+```
+
+### Perspective: Export Selected Widgets by Name
+
+```python
+csvBytes = system.mes.dashboard.exportWidgetsAsCsv(["Time Series", "Summary"])
+system.perspective.download("widgets.csv", csvBytes)
+```

--- a/docs/appendix/script-api/dashboard-script-api/export-widgets-as-json.md
+++ b/docs/appendix/script-api/dashboard-script-api/export-widgets-as-json.md
@@ -1,0 +1,53 @@
+---
+sidebar_position: 33
+title: "exportWidgetsAsJson"
+description: "Exports dashboard widgets as raw bytes in JSON format (UTF-8 encoded)."
+---
+
+# system.mes.dashboard.exportWidgetsAsJson
+
+## Description
+
+Exports dashboard widgets as raw bytes in JSON format (UTF-8 encoded). Use the no-argument form to export all widgets,
+or pass a list of widget IDs or names to export only those selected widgets.
+
+## Syntax
+
+```python
+system.mes.dashboard.exportWidgetsAsJson()
+system.mes.dashboard.exportWidgetsAsJson(idsOrNames)
+```
+
+## Parameters
+
+### Method 1: No Parameters (Export All Widgets)
+
+| Parameter | Type | Nullable | Description                               |
+|-----------|------|----------|-------------------------------------------|
+| None      | -    | -        | This method does not take any parameters. |
+
+### Method 2: Export Selected Widgets by ID or Name
+
+| Parameter    | Type           | Nullable | Description                              |
+|--------------|----------------|----------|------------------------------------------|
+| `idsOrNames` | `List<String>` | False    | A list of widget IDs or names to export. |
+
+## Returns
+
+A Byte array (Byte[]) containing the raw JSON bytes of the exported widgets.
+
+## Code Examples
+
+### Perspective: Export All Widgets
+
+```python
+jsonBytes = system.mes.dashboard.exportWidgetsAsJson()
+system.perspective.download("widgets.json", jsonBytes)
+```
+
+### Perspective: Export Selected Widgets by Name
+
+```python
+jsonBytes = system.mes.dashboard.exportWidgetsAsJson(["Time Series", "Summary"])
+system.perspective.download("widgets.json", jsonBytes)
+```

--- a/docs/appendix/script-api/dashboard-script-api/get-all-widget-names.md
+++ b/docs/appendix/script-api/dashboard-script-api/get-all-widget-names.md
@@ -1,0 +1,34 @@
+---
+sidebar_position: 13
+title: "getAllWidgetNames"
+description: "Retrieves the names of all dashboard widgets."
+---
+
+# system.mes.dashboard.getAllWidgetNames
+
+## Description
+
+Retrieves the names of all registered Dashboard Widgets.
+
+## Syntax
+
+```python
+system.mes.dashboard.getAllWidgetNames()
+```
+
+## Parameters
+
+| Parameter | Type | Nullable | Description                               |
+|-----------|------|----------|-------------------------------------------|
+| None      | -    | -        | This method does not take any parameters. |
+
+## Returns
+
+Returns a list of `String` names.
+
+## Code Examples
+
+```python
+names = system.mes.dashboard.getAllWidgetNames()
+print(names)
+```

--- a/docs/appendix/script-api/dashboard-script-api/get-dashboard-by-url.md
+++ b/docs/appendix/script-api/dashboard-script-api/get-dashboard-by-url.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 27
+title: "getDashboardByUrl"
+description: "Retrieves a dashboard by URL for the current authenticated user (or public dashboards)."
+---
+
+# system.mes.dashboard.getDashboardByUrl
+
+## Description
+
+Retrieves a Dashboard by its URL for the current authenticated user. Public dashboards (no owner) are also considered.
+If the user isn’t authenticated or the dashboard isn’t found for that user, this call throws an error.
+
+## Syntax
+
+```python
+system.mes.dashboard.getDashboardByUrl(url)
+```
+
+## Parameters
+
+| Parameter | Type     | Nullable | Description                                |
+|-----------|----------|----------|--------------------------------------------|
+| `url`     | `String` | False    | The URL slug of the dashboard to retrieve. |
+
+## Returns
+
+Returns a JSON representation of the dashboard. See [getDashboard](./get-dashboard) for the field list.
+
+## Code Examples
+
+```python
+db = system.mes.dashboard.getDashboardByUrl('production-overview')
+print(db)
+```

--- a/docs/appendix/script-api/dashboard-script-api/get-dashboard.md
+++ b/docs/appendix/script-api/dashboard-script-api/get-dashboard.md
@@ -1,0 +1,55 @@
+---
+sidebar_position: 26
+title: "getDashboard"
+description: "Retrieves a dashboard by ID."
+---
+
+# system.mes.dashboard.getDashboard
+
+## Description
+
+Retrieves a Dashboard by its ID.
+
+## Syntax
+
+```python
+system.mes.dashboard.getDashboard(id)
+```
+
+## Parameters
+
+| Parameter | Type            | Nullable | Description                          |
+|-----------|-----------------|----------|--------------------------------------|
+| `id`      | `String` (ULID) | False    | The ID of the dashboard to retrieve. |
+
+## Returns
+
+Returns a JSON representation of the dashboard.
+
+| Name               | Type            | Description                                                 |
+|--------------------|-----------------|-------------------------------------------------------------|
+| `name`             | `String`        | The user-given name for the dashboard.                      |
+| `url`              | `String`        | URL-friendly version used for page routing.                 |
+| `isPublic`         | `Boolean`       | True if the dashboard is public.                            |
+| `username`         | `String`        | Owner’s Ignition username (null if public).                 |
+| `iconPath`         | `String`        | Path to an icon for the dashboard.                          |
+| `pack`             | `Boolean`       | Enables auto-size to fit content.                           |
+| `grid`             | `String`        | Grid layout mode (e.g., STRETCH).                           |
+| `rowCount`         | `Integer`       | Number of grid rows (fixed layout).                         |
+| `columnCount`      | `Integer`       | Number of grid columns (fixed layout).                      |
+| `rowGutterSize`    | `Integer`       | Vertical spacing between rows (fixed layout).               |
+| `columnGutterSize` | `Integer`       | Horizontal spacing between columns (fixed layout).          |
+| `instancesJson`    | `String`        | JSON for Perspective dashboard component `props.instances`. |
+| `id`               | `String` (ULID) | The ULID of the dashboard.                                  |
+| `notes`            | `String`        | Notes related to the dashboard.                             |
+| `enabled`          | `Boolean`       | Indicates if the dashboard is active and enabled.           |
+| `spare1`           | `String`        | Additional field for user-defined context.                  |
+| `spare2`           | `String`        | Additional field for user-defined context.                  |
+| `spare3`           | `String`        | Additional field for user-defined context.                  |
+
+## Code Examples
+
+```python
+db = system.mes.dashboard.getDashboard('01JAP8RJBN-8ZTPXSGY-J9GSDPE1')
+print(db)
+```

--- a/docs/appendix/script-api/dashboard-script-api/get-dashboards-for-current-user.md
+++ b/docs/appendix/script-api/dashboard-script-api/get-dashboards-for-current-user.md
@@ -1,0 +1,34 @@
+---
+sidebar_position: 28
+title: "getDashboardsForCurrentUser"
+description: "Retrieves dashboards for the current user and all public dashboards."
+---
+
+# system.mes.dashboard.getDashboardsForCurrentUser
+
+## Description
+
+Retrieves all dashboards owned by the current authenticated user, plus all public dashboards.
+
+## Syntax
+
+```python
+system.mes.dashboard.getDashboardsForCurrentUser()
+```
+
+## Parameters
+
+| Parameter | Type | Nullable | Description                               |
+|-----------|------|----------|-------------------------------------------|
+| None      | -    | -        | This method does not take any parameters. |
+
+## Returns
+
+Returns a list of JSON objects representing dashboards. See [getDashboard](./get-dashboard) for fields.
+
+## Code Examples
+
+```python
+items = system.mes.dashboard.getDashboardsForCurrentUser()
+print(items)
+```

--- a/docs/appendix/script-api/dashboard-script-api/get-parameter-type-by-name.md
+++ b/docs/appendix/script-api/dashboard-script-api/get-parameter-type-by-name.md
@@ -1,0 +1,45 @@
+---
+sidebar_position: 4
+title: "getParameterTypeByName"
+description: "Retrieves a dashboard widget parameter type by name."
+---
+
+# system.mes.dashboard.getParameterTypeByName
+
+## Description
+
+Retrieves a Dashboard Widget Parameter Type by its unique name.
+
+## Syntax
+
+```python
+system.mes.dashboard.getParameterTypeByName(name)
+```
+
+## Parameters
+
+| Parameter | Type     | Nullable | Description                                 |
+|-----------|----------|----------|---------------------------------------------|
+| `name`    | `String` | False    | The name of the parameter type to retrieve. |
+
+## Returns
+
+Returns a JSON representation of the parameter type.
+
+| Name       | Type            | Description                                             |
+|------------|-----------------|---------------------------------------------------------|
+| `name`     | `String`        | The unique name of the parameter type.                  |
+| `viewPath` | `String`        | Perspective view path used to edit this parameter type. |
+| `id`       | `String` (ULID) | The ULID of the parameter type.                         |
+| `notes`    | `String`        | Notes related to the parameter type.                    |
+| `enabled`  | `Boolean`       | Indicates if the parameter type is active and enabled.  |
+| `spare1`   | `String`        | Additional field for user-defined context.              |
+| `spare2`   | `String`        | Additional field for user-defined context.              |
+| `spare3`   | `String`        | Additional field for user-defined context.              |
+
+## Code Examples
+
+```python
+pt = system.mes.dashboard.getParameterTypeByName('Integer')
+print(pt)
+```

--- a/docs/appendix/script-api/dashboard-script-api/get-parameter-type.md
+++ b/docs/appendix/script-api/dashboard-script-api/get-parameter-type.md
@@ -1,0 +1,45 @@
+---
+sidebar_position: 3
+title: "getParameterType"
+description: "Retrieves a dashboard widget parameter type by ID."
+---
+
+# system.mes.dashboard.getParameterType
+
+## Description
+
+Retrieves a Dashboard Widget Parameter Type by its ID.
+
+## Syntax
+
+```python
+system.mes.dashboard.getParameterType(id)
+```
+
+## Parameters
+
+| Parameter | Type            | Nullable | Description                               |
+|-----------|-----------------|----------|-------------------------------------------|
+| `id`      | `String` (ULID) | False    | The ID of the parameter type to retrieve. |
+
+## Returns
+
+Returns a JSON representation of the parameter type.
+
+| Name       | Type            | Description                                             |
+|------------|-----------------|---------------------------------------------------------|
+| `name`     | `String`        | The unique name of the parameter type.                  |
+| `viewPath` | `String`        | Perspective view path used to edit this parameter type. |
+| `id`       | `String` (ULID) | The ULID of the parameter type.                         |
+| `notes`    | `String`        | Notes related to the parameter type.                    |
+| `enabled`  | `Boolean`       | Indicates if the parameter type is active and enabled.  |
+| `spare1`   | `String`        | Additional field for user-defined context.              |
+| `spare2`   | `String`        | Additional field for user-defined context.              |
+| `spare3`   | `String`        | Additional field for user-defined context.              |
+
+## Code Examples
+
+```python
+pt = system.mes.dashboard.getParameterType('01JAP8RJBN-8ZTPXSGY-J9GSDPE1')
+print(pt)
+```

--- a/docs/appendix/script-api/dashboard-script-api/get-parameter-types.md
+++ b/docs/appendix/script-api/dashboard-script-api/get-parameter-types.md
@@ -1,0 +1,34 @@
+---
+sidebar_position: 5
+title: "getParameterTypes"
+description: "Retrieves all dashboard widget parameter types."
+---
+
+# system.mes.dashboard.getParameterTypes
+
+## Description
+
+Retrieves a list of all Dashboard Widget Parameter Types.
+
+## Syntax
+
+```python
+system.mes.dashboard.getParameterTypes()
+```
+
+## Parameters
+
+| Parameter | Type | Nullable | Description                               |
+|-----------|------|----------|-------------------------------------------|
+| None      | -    | -        | This method does not take any parameters. |
+
+## Returns
+
+Returns a list of JSON objects representing parameter types.
+
+## Code Examples
+
+```python
+allTypes = system.mes.dashboard.getParameterTypes()
+print(allTypes)
+```

--- a/docs/appendix/script-api/dashboard-script-api/get-widget-by-name.md
+++ b/docs/appendix/script-api/dashboard-script-api/get-widget-by-name.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 11
+title: "getWidgetByName"
+description: "Retrieves a dashboard widget by name."
+---
+
+# system.mes.dashboard.getWidgetByName
+
+## Description
+
+Retrieves a Dashboard Widget by its unique name.
+
+## Syntax
+
+```python
+system.mes.dashboard.getWidgetByName(name)
+```
+
+## Parameters
+
+| Parameter | Type     | Nullable | Description                    |
+|-----------|----------|----------|--------------------------------|
+| `name`    | `String` | False    | The name of the widget to get. |
+
+## Returns
+
+Returns a JSON representation of the widget.
+
+| Name            | Type            | Description                                        |
+|-----------------|-----------------|----------------------------------------------------|
+| `name`          | `String`        | The user-friendly name of the widget.              |
+| `description`   | `String`        | Description of the widget functionality.           |
+| `viewPath`      | `String`        | Path to the Ignition View that renders the widget. |
+| `iconPath`      | `String`        | Path to an icon for the widget.                    |
+| `category`      | `String`        | Category of the widget.                            |
+| `defaultWidth`  | `Integer`       | Default grid width of the widget.                  |
+| `defaultHeight` | `Integer`       | Default grid height of the widget.                 |
+| `minWidth`      | `Integer`       | Minimum grid width allowed.                        |
+| `minHeight`     | `Integer`       | Minimum grid height allowed.                       |
+| `id`            | `String` (ULID) | The ULID of the widget.                            |
+| `notes`         | `String`        | Notes related to the widget.                       |
+| `enabled`       | `Boolean`       | Indicates if the widget is active and enabled.     |
+| `spare1`        | `String`        | Additional field for user-defined context.         |
+| `spare2`        | `String`        | Additional field for user-defined context.         |
+| `spare3`        | `String`        | Additional field for user-defined context.         |
+
+## Code Examples
+
+```python
+w = system.mes.dashboard.getWidgetByName('Time Series')
+print(w)
+```

--- a/docs/appendix/script-api/dashboard-script-api/get-widget-parameter.md
+++ b/docs/appendix/script-api/dashboard-script-api/get-widget-parameter.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 21
+title: "getWidgetParameter"
+description: "Retrieves a dashboard widget parameter by ID."
+---
+
+# system.mes.dashboard.getWidgetParameter
+
+## Description
+
+Retrieves a Dashboard Widget Parameter by its ID.
+
+## Syntax
+
+```python
+system.mes.dashboard.getWidgetParameter(parameterId)
+```
+
+## Parameters
+
+| Parameter     | Type            | Nullable | Description                                 |
+|---------------|-----------------|----------|---------------------------------------------|
+| `parameterId` | `String` (ULID) | False    | The ID of the widget parameter to retrieve. |
+
+## Returns
+
+Returns a JSON representation of the widget parameter, or nothing if not found.
+
+| Name              | Type            | Description                                              |
+|-------------------|-----------------|----------------------------------------------------------|
+| `widgetId`        | `String` (ULID) | The ULID of the widget this parameter belongs to.        |
+| `parameterTypeId` | `String` (ULID) | The ULID of the parameter type used by this parameter.   |
+| `name`            | `String`        | The display label for the parameter.                     |
+| `description`     | `String`        | Description of what the parameter controls.              |
+| `parameterKey`    | `String`        | The key used in the widget's view parameters.            |
+| `defaultValue`    | `String`        | JSON string of the default value.                        |
+| `configuration`   | `String`        | JSON string configuring the parameter editor.            |
+| `sortOrder`       | `Integer`       | Determines display order in the widget configuration UI. |
+| `id`              | `String` (ULID) | The ULID of the widget parameter.                        |
+| `notes`           | `String`        | Notes related to the widget parameter.                   |
+| `enabled`         | `Boolean`       | Indicates if the widget parameter is active and enabled. |
+| `spare1`          | `String`        | Additional field for user-defined context.               |
+| `spare2`          | `String`        | Additional field for user-defined context.               |
+| `spare3`          | `String`        | Additional field for user-defined context.               |
+
+## Code Examples
+
+```python
+param = system.mes.dashboard.getWidgetParameter('01JAP8RJBN-8ZTPXSGY-J9GSDPE1')
+print(param)
+```

--- a/docs/appendix/script-api/dashboard-script-api/get-widget-parameters.md
+++ b/docs/appendix/script-api/dashboard-script-api/get-widget-parameters.md
@@ -1,0 +1,34 @@
+---
+sidebar_position: 19
+title: "getWidgetParameters"
+description: "Retrieves all parameters for a specific dashboard widget."
+---
+
+# system.mes.dashboard.getWidgetParameters
+
+## Description
+
+Retrieves all parameters for the specified Dashboard Widget.
+
+## Syntax
+
+```python
+system.mes.dashboard.getWidgetParameters(widgetId)
+```
+
+## Parameters
+
+| Parameter  | Type            | Nullable | Description                              |
+|------------|-----------------|----------|------------------------------------------|
+| `widgetId` | `String` (ULID) | False    | The ID of the widget to retrieve params. |
+
+## Returns
+
+Returns a list of JSON objects representing widget parameters.
+
+## Code Examples
+
+```python
+params = system.mes.dashboard.getWidgetParameters('01JAP8RJBN-8ZTPXSGY-J9GSDPE1')
+print(params)
+```

--- a/docs/appendix/script-api/dashboard-script-api/get-widget.md
+++ b/docs/appendix/script-api/dashboard-script-api/get-widget.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 10
+title: "getWidget"
+description: "Retrieves a dashboard widget by ID."
+---
+
+# system.mes.dashboard.getWidget
+
+## Description
+
+Retrieves a Dashboard Widget by its ID.
+
+## Syntax
+
+```python
+system.mes.dashboard.getWidget(id)
+```
+
+## Parameters
+
+| Parameter | Type            | Nullable | Description                       |
+|-----------|-----------------|----------|-----------------------------------|
+| `id`      | `String` (ULID) | False    | The ID of the widget to retrieve. |
+
+## Returns
+
+Returns a JSON representation of the widget.
+
+| Name            | Type            | Description                                        |
+|-----------------|-----------------|----------------------------------------------------|
+| `name`          | `String`        | The user-friendly name of the widget.              |
+| `description`   | `String`        | Description of the widget functionality.           |
+| `viewPath`      | `String`        | Path to the Ignition View that renders the widget. |
+| `iconPath`      | `String`        | Path to an icon for the widget.                    |
+| `category`      | `String`        | Category of the widget.                            |
+| `defaultWidth`  | `Integer`       | Default grid width of the widget.                  |
+| `defaultHeight` | `Integer`       | Default grid height of the widget.                 |
+| `minWidth`      | `Integer`       | Minimum grid width allowed.                        |
+| `minHeight`     | `Integer`       | Minimum grid height allowed.                       |
+| `id`            | `String` (ULID) | The ULID of the widget.                            |
+| `notes`         | `String`        | Notes related to the widget.                       |
+| `enabled`       | `Boolean`       | Indicates if the widget is active and enabled.     |
+| `spare1`        | `String`        | Additional field for user-defined context.         |
+| `spare2`        | `String`        | Additional field for user-defined context.         |
+| `spare3`        | `String`        | Additional field for user-defined context.         |
+
+## Code Examples
+
+```python
+w = system.mes.dashboard.getWidget('01JAP8RJBN-8ZTPXSGY-J9GSDPE1')
+print(w)
+```

--- a/docs/appendix/script-api/dashboard-script-api/get-widgets.md
+++ b/docs/appendix/script-api/dashboard-script-api/get-widgets.md
@@ -1,0 +1,34 @@
+---
+sidebar_position: 12
+title: "getWidgets"
+description: "Retrieves all dashboard widgets."
+---
+
+# system.mes.dashboard.getWidgets
+
+## Description
+
+Retrieves a list of all Dashboard Widgets.
+
+## Syntax
+
+```python
+system.mes.dashboard.getWidgets()
+```
+
+## Parameters
+
+| Parameter | Type | Nullable | Description                               |
+|-----------|------|----------|-------------------------------------------|
+| None      | -    | -        | This method does not take any parameters. |
+
+## Returns
+
+Returns a list of JSON objects representing widgets.
+
+## Code Examples
+
+```python
+widgets = system.mes.dashboard.getWidgets()
+print(widgets)
+```

--- a/docs/appendix/script-api/dashboard-script-api/import-from-csv.md
+++ b/docs/appendix/script-api/dashboard-script-api/import-from-csv.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 35
+title: "importFromCsv"
+description: "Imports dashboard widgets from a CSV file provided as raw bytes."
+---
+
+# system.mes.dashboard.importFromCsv
+
+## Description
+
+Imports Dashboard Widgets from a CSV file provided as raw bytes. The service parses the CSV content and creates or
+updates widgets and their metadata accordingly.
+
+## Syntax
+
+```python
+system.mes.dashboard.importFromCsv(importBytes)
+```
+
+## Parameters
+
+| Parameter     | Type      | Nullable | Description                        |
+|---------------|-----------|----------|------------------------------------|
+| `importBytes` | `PyArray` | False    | The CSV file content as raw bytes. |
+
+## Returns
+
+An ApiResponse object indicating success or failure of the import.
+
+| Name      | Type      | Description                                       |
+|-----------|-----------|---------------------------------------------------|
+| `success` | `Boolean` | Indicates if the import was successful.           |
+| `message` | `String`  | Details about the import outcome.                 |
+| `data`    | `Integer` | The number of widgets imported (when successful). |
+| `error`   | `String`  | Error details if the import failed.               |
+
+## Code Examples
+
+### Perspective File Upload (onFileReceived)
+
+```python
+def runAction(self, event):
+    csvBytes = event.file.getBytes()
+    response = system.mes.dashboard.importFromCsv(csvBytes)
+    print(response)
+```

--- a/docs/appendix/script-api/dashboard-script-api/import-from-json.md
+++ b/docs/appendix/script-api/dashboard-script-api/import-from-json.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 36
+title: "importFromJson"
+description: "Imports dashboard widgets from a JSON file provided as raw bytes."
+---
+
+# system.mes.dashboard.importFromJson
+
+## Description
+
+Imports Dashboard Widgets from a JSON file provided as raw bytes. The service parses the JSON content and creates or
+updates widgets and their metadata accordingly.
+
+## Syntax
+
+```python
+system.mes.dashboard.importFromJson(importBytes)
+```
+
+## Parameters
+
+| Parameter     | Type      | Nullable | Description                         |
+|---------------|-----------|----------|-------------------------------------|
+| `importBytes` | `PyArray` | False    | The JSON file content as raw bytes. |
+
+## Returns
+
+An ApiResponse object indicating success or failure of the import.
+
+| Name      | Type      | Description                                       |
+|-----------|-----------|---------------------------------------------------|
+| `success` | `Boolean` | Indicates if the import was successful.           |
+| `message` | `String`  | Details about the import outcome.                 |
+| `data`    | `Integer` | The number of widgets imported (when successful). |
+| `error`   | `String`  | Error details if the import failed.               |
+
+## Code Examples
+
+### Perspective File Upload (onFileReceived)
+
+```python
+def runAction(self, event):
+    jsonBytes = event.file.getBytes()
+    response = system.mes.dashboard.importFromJson(jsonBytes)
+    print(response)
+```

--- a/docs/appendix/script-api/dashboard-script-api/intro.md
+++ b/docs/appendix/script-api/dashboard-script-api/intro.md
@@ -1,0 +1,151 @@
+---
+sidebar_position: 1
+title: "Introduction to Dashboard API"
+description: "Overview of functions available in the Dashboard API."
+---
+
+# Dashboard API
+
+Welcome to the Dashboard API documentation. This API provides a comprehensive set of functions for managing dashboards, reusable widgets, parameter types, and bulk import/export of widgets. Below is a list of available functions, each with a brief description and a link to its detailed documentation.
+
+## Function List
+
+### [`newParameterType`](./new-parameter-type)
+
+Generates an empty non-persisted Dashboard Widget Parameter Type to provide the structure required by the API to save a new record into the database. This method must be combined with the [saveParameterType](./save-parameter-type) method in order to persist the record. Returns a JSON representation of the newly created parameter type object.
+
+### [`getParameterType`](./get-parameter-type)
+
+Retrieves a Dashboard Widget Parameter Type by its ID. Returns a JSON representation of the parameter type.
+
+### [`getParameterTypeByName`](./get-parameter-type-by-name)
+
+Retrieves a Dashboard Widget Parameter Type by its unique name. Returns a JSON representation of the parameter type.
+
+### [`getParameterTypes`](./get-parameter-types)
+
+Retrieves a list of all Dashboard Widget Parameter Types. Returns a list of JSON objects representing parameter types.
+
+### [`saveParameterType`](./save-parameter-type)
+
+Creates or updates a Dashboard Widget Parameter Type in the system based on the provided parameters. Returns a JSON representation of the saved parameter type.
+
+### [`validateParameterType`](./validate-parameter-type)
+
+Validates the specified parameters for a Dashboard Widget Parameter Type and returns any validation errors. This only checks if the object can be saved based on the attributes given. Returns a JSON object where keys are field names and values are lists of validation violation messages.
+
+### [`deleteParameterType`](./delete-parameter-type)
+
+Deletes a Dashboard Widget Parameter Type by its ID. If successful, an ApiResponse Object is returned with the success bool set True.
+
+### [`newWidget`](./new-widget)
+
+Generates an empty non-persisted Dashboard Widget to provide the structure required by the API to save a new record into the database. This method must be combined with the [saveWidget](./save-widget) method in order to persist the record. Returns a JSON representation of the newly created widget object.
+
+### [`getWidget`](./get-widget)
+
+Retrieves a Dashboard Widget by its ID. Returns a JSON representation of the widget.
+
+### [`getWidgetByName`](./get-widget-by-name)
+
+Retrieves a Dashboard Widget by its unique name. Returns a JSON representation of the widget.
+
+### [`getWidgets`](./get-widgets)
+
+Retrieves a list of all Dashboard Widgets. Returns a list of JSON objects representing widgets.
+
+### [`getAllWidgetNames`](./get-all-widget-names)
+
+Retrieves the names of all registered Dashboard Widgets. Returns a list of Strings.
+
+### [`saveWidget`](./save-widget)
+
+Creates or updates a Dashboard Widget in the system based on the provided parameters. Returns a JSON representation of the saved widget.
+
+### [`saveWidgetAndParameters`](./save-widget-and-parameters)
+
+Saves a Dashboard Widget and its parameters in one call. Parameters provided are saved or updated; any existing parameters not in the list are removed. Returns a JSON representation of the saved widget.
+
+### [`validateWidget`](./validate-widget)
+
+Validates the specified parameters for a Dashboard Widget and returns any validation errors. This only checks if the object can be saved based on the attributes given. Returns a JSON object where keys are field names and values are lists of validation violation messages.
+
+### [`saveWidgets`](./save-widgets)
+
+Saves a list of Dashboard Widgets in bulk (useful for gateway startup). Returns a list of JSON objects representing the saved widgets.
+
+### [`deleteWidget`](./delete-widget)
+
+Deletes a Dashboard Widget by its ID. If successful, an ApiResponse Object is returned with the success bool set True.
+
+### [`getWidgetParameters`](./get-widget-parameters)
+
+Retrieves all parameters for a specific Dashboard Widget. Returns a list of JSON objects representing widget parameters.
+
+### [`newWidgetParameter`](./new-widget-parameter)
+
+Generates an empty non-persisted Dashboard Widget Parameter to provide the structure required by the API to save a new record into the database. This method must be combined with the [saveWidgetParameter](./save-widget-parameter) method in order to persist the record. Returns a JSON representation of the newly created widget parameter object.
+
+### [`getWidgetParameter`](./get-widget-parameter)
+
+Retrieves a Dashboard Widget Parameter by its ID. Returns a JSON representation of the widget parameter.
+
+### [`saveWidgetParameter`](./save-widget-parameter)
+
+Creates or updates a Dashboard Widget Parameter in the system based on the provided parameters. Returns a JSON representation of the saved widget parameter.
+
+### [`validateWidgetParameter`](./validate-widget-parameter)
+
+Validates the specified parameters for a Dashboard Widget Parameter and returns any validation errors. This only checks if the object can be saved based on the attributes given. Returns a JSON object where keys are field names and values are lists of validation violation messages.
+
+### [`deleteWidgetParameter`](./delete-widget-parameter)
+
+Deletes a Dashboard Widget Parameter by its ID. If successful, an ApiResponse Object is returned with the success bool set True.
+
+### [`newDashboard`](./new-dashboard)
+
+Generates an empty non-persisted Dashboard to provide the structure required by the API to save a new record into the database. This method must be combined with the [saveDashboard](./save-dashboard) method in order to persist the record. Returns a JSON representation of the newly created dashboard object.
+
+### [`getDashboard`](./get-dashboard)
+
+Retrieves a Dashboard by its ID. Returns a JSON representation of the dashboard.
+
+### [`getDashboardByUrl`](./get-dashboard-by-url)
+
+Retrieves a Dashboard by its URL for the current authenticated user (public dashboards are also considered). Returns a JSON representation of the dashboard.
+
+### [`getDashboardsForCurrentUser`](./get-dashboards-for-current-user)
+
+Retrieves all dashboards owned by the current authenticated user, plus all public dashboards. Returns a list of JSON objects representing dashboards.
+
+### [`saveDashboard`](./save-dashboard)
+
+Creates or updates a Dashboard in the system based on the provided parameters. Returns a JSON representation of the saved dashboard.
+
+### [`validateDashboard`](./validate-dashboard)
+
+Validates the specified parameters for a Dashboard and returns any validation errors. This only checks if the object can be saved based on the attributes given. Returns a JSON object where keys are field names and values are lists of validation violation messages.
+
+### [`deleteDashboard`](./delete-dashboard)
+
+Deletes a Dashboard by its ID. If successful, an ApiResponse Object is returned with the success bool set True.
+
+### [`isUrlUnique`](./is-url-unique)
+
+Checks whether a dashboard URL is unique for a given username (and not used by any public dashboard), with an optional `excludeId` for updates. Returns a boolean.
+
+### [`exportWidgetsAsJson`](./export-widgets-as-json)
+
+Exports Dashboard Widgets as raw bytes in JSON format (UTF-8 encoded). Use without parameters to export all widgets or pass a list of IDs or names to export only selected widgets.
+
+### [`exportWidgetsAsCsv`](./export-widgets-as-csv)
+
+Exports Dashboard Widgets as raw bytes in CSV format (UTF-8 encoded). Use without parameters to export all widgets or pass a list of IDs or names to export only selected widgets.
+
+### [`importFromCsv`](./import-from-csv)
+
+Imports Dashboard Widgets from a CSV file provided as raw bytes. Returns an ApiResponse with outcome details.
+
+### [`importFromJson`](./import-from-json)
+
+Imports Dashboard Widgets from a JSON file provided as raw bytes. Returns an ApiResponse with outcome details.

--- a/docs/appendix/script-api/dashboard-script-api/is-url-unique.md
+++ b/docs/appendix/script-api/dashboard-script-api/is-url-unique.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 32
+title: "isUrlUnique"
+description: "Checks whether a dashboard URL is unique for a given user, with optional excludeId for updates."
+---
+
+# system.mes.dashboard.isUrlUnique
+
+## Description
+
+Checks if a URL is unique and available for use by a specific user. A URL is unavailable if it already exists for either
+the same username or any public dashboard (username is null).
+
+## Syntax
+
+```python
+system.mes.dashboard.isUrlUnique(url, username)
+system.mes.dashboard.isUrlUnique(url, username, excludeId)
+```
+
+## Parameters
+
+### Method 1: URL and Username
+
+| Parameter  | Type     | Nullable | Description                               |
+|------------|----------|----------|-------------------------------------------|
+| `url`      | `String` | False    | The URL to check for uniqueness.          |
+| `username` | `String` | False    | The username that will own the dashboard. |
+
+### Method 2: URL, Username, and Exclude ID
+
+| Parameter   | Type            | Nullable | Description                                                                           |
+|-------------|-----------------|----------|---------------------------------------------------------------------------------------|
+| `url`       | `String`        | False    | The URL to check for uniqueness.                                                      |
+| `username`  | `String`        | False    | The username that will own the dashboard.                                             |
+| `excludeId` | `String` (ULID) | True     | An existing dashboard ID to exclude from the uniqueness check (useful when updating). |
+
+## Returns
+
+Returns a Boolean indicating whether the URL is unique and can be used.
+
+## Code Examples
+
+```python
+# Check URL availability for current user
+isUnique = system.mes.dashboard.isUrlUnique('production-overview', 'operator01')
+print(isUnique)
+
+# Check URL availability while updating an existing dashboard
+isUnique = system.mes.dashboard.isUrlUnique('production-overview', 'operator01', '01JAP8RJBN-8ZTPXSGY-J9GSDPE1')
+print(isUnique)
+```

--- a/docs/appendix/script-api/dashboard-script-api/new-dashboard.md
+++ b/docs/appendix/script-api/dashboard-script-api/new-dashboard.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 25
+title: "newDashboard"
+description: "Generates an empty Dashboard object to use with saveDashboard."
+---
+
+# system.mes.dashboard.newDashboard
+
+## Description
+
+Generates an empty non-persisted Dashboard object to provide the structure required by the API to save a new record into
+the database. Use with [saveDashboard](./save-dashboard).
+
+## Syntax
+
+```python
+system.mes.dashboard.newDashboard()
+```
+
+## Parameters
+
+| Parameter | Type | Nullable | Description                               |
+|-----------|------|----------|-------------------------------------------|
+| None      | -    | -        | This method does not take any parameters. |
+
+## Returns
+
+Returns a JSON representation of the newly created dashboard object. Keys and default values:
+
+| Key                | Default Value          |
+|--------------------|------------------------|
+| `name`             | `null`                 |
+| `url`              | `null`                 |
+| `isPublic`         | `false`                |
+| `username`         | `null`                 |
+| `iconPath`         | `"material/dashboard"` |
+| `pack`             | `true`                 |
+| `grid`             | `STRETCH`              |
+| `rowCount`         | `10`                   |
+| `columnCount`      | `10`                   |
+| `rowGutterSize`    | `8`                    |
+| `columnGutterSize` | `8`                    |
+| `instancesJson`    | `null`                 |
+| `id`               | `null`                 |
+| `notes`            | `null`                 |
+| `enabled`          | `true`                 |
+| `spare1`           | `null`                 |
+| `spare2`           | `null`                 |
+| `spare3`           | `null`                 |
+
+## Code Examples
+
+```python
+db = system.mes.dashboard.newDashboard()
+db['name'] = 'Production Overview'
+db['url'] = 'production-overview'
+db['instancesJson'] = '[]'
+print(db)
+```

--- a/docs/appendix/script-api/dashboard-script-api/new-parameter-type.md
+++ b/docs/appendix/script-api/dashboard-script-api/new-parameter-type.md
@@ -1,0 +1,49 @@
+---
+sidebar_position: 2
+title: "newParameterType"
+description: "Generates an empty Dashboard Widget Parameter Type object to use with saveParameterType."
+---
+
+# system.mes.dashboard.newParameterType
+
+## Description
+
+Generates an empty non-persisted parameter type object to provide the structure required by the API to save a new record
+into the database. Use with [saveParameterType](./save-parameter-type).
+
+## Syntax
+
+```python
+system.mes.dashboard.newParameterType()
+```
+
+## Parameters
+
+| Parameter | Type | Nullable | Description                               |
+|-----------|------|----------|-------------------------------------------|
+| None      | -    | -        | This method does not take any parameters. |
+
+## Returns
+
+Returns a JSON representation of the newly created parameter type object. Keys and default values:
+
+| Key        | Default Value |
+|------------|---------------|
+| `name`     | `null`        |
+| `viewPath` | `null`        |
+| `id`       | `null`        |
+| `notes`    | `null`        |
+| `enabled`  | `true`        |
+| `spare1`   | `null`        |
+| `spare2`   | `null`        |
+| `spare3`   | `null`        |
+
+## Code Examples
+
+```python
+pt = system.mes.dashboard.newParameterType()
+pt['name'] = 'Integer'
+pt['viewPath'] = 'Mes/Editors/Integer'
+saved = system.mes.dashboard.saveParameterType(pt)
+print(saved)
+```

--- a/docs/appendix/script-api/dashboard-script-api/new-widget-parameter.md
+++ b/docs/appendix/script-api/dashboard-script-api/new-widget-parameter.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 20
+title: "newWidgetParameter"
+description: "Generates an empty Dashboard Widget Parameter object to use with saveWidgetParameter."
+---
+
+# system.mes.dashboard.newWidgetParameter
+
+## Description
+
+Generates an empty non-persisted widget parameter object to provide the structure required by the API to save a new
+record into the database. Use with [saveWidgetParameter](./save-widget-parameter).
+
+## Syntax
+
+```python
+system.mes.dashboard.newWidgetParameter()
+```
+
+## Parameters
+
+| Parameter | Type | Nullable | Description                               |
+|-----------|------|----------|-------------------------------------------|
+| None      | -    | -        | This method does not take any parameters. |
+
+## Returns
+
+Returns a JSON representation of the newly created widget parameter object. Keys and default values:
+
+| Key               | Default Value |
+|-------------------|---------------|
+| `widgetId`        | `null`        |
+| `parameterTypeId` | `null`        |
+| `name`            | `null`        |
+| `description`     | `null`        |
+| `parameterKey`    | `null`        |
+| `defaultValue`    | `null`        |
+| `configuration`   | `null`        |
+| `sortOrder`       | `0`           |
+| `id`              | `null`        |
+| `notes`           | `null`        |
+| `enabled`         | `true`        |
+| `spare1`          | `null`        |
+| `spare2`          | `null`        |
+| `spare3`          | `null`        |
+
+## Code Examples
+
+```python
+p = system.mes.dashboard.newWidgetParameter()
+p['name'] = 'Chart Title'
+p['parameterKey'] = 'title'
+print(p)
+```

--- a/docs/appendix/script-api/dashboard-script-api/new-widget.md
+++ b/docs/appendix/script-api/dashboard-script-api/new-widget.md
@@ -1,0 +1,56 @@
+---
+sidebar_position: 9
+title: "newWidget"
+description: "Generates an empty Dashboard Widget object to use with saveWidget."
+---
+
+# system.mes.dashboard.newWidget
+
+## Description
+
+Generates an empty non-persisted widget object to provide the structure required by the API to save a new record into
+the database. Use with [saveWidget](./save-widget).
+
+## Syntax
+
+```python
+system.mes.dashboard.newWidget()
+```
+
+## Parameters
+
+| Parameter | Type | Nullable | Description                               |
+|-----------|------|----------|-------------------------------------------|
+| None      | -    | -        | This method does not take any parameters. |
+
+## Returns
+
+Returns a JSON representation of the newly created widget object. Keys and default values:
+
+| Key             | Default Value |
+|-----------------|---------------|
+| `name`          | `null`        |
+| `description`   | `null`        |
+| `viewPath`      | `null`        |
+| `iconPath`      | `null`        |
+| `category`      | `null`        |
+| `defaultWidth`  | `2`           |
+| `defaultHeight` | `2`           |
+| `minWidth`      | `2`           |
+| `minHeight`     | `2`           |
+| `id`            | `null`        |
+| `notes`         | `null`        |
+| `enabled`       | `true`        |
+| `spare1`        | `null`        |
+| `spare2`        | `null`        |
+| `spare3`        | `null`        |
+
+## Code Examples
+
+```python
+w = system.mes.dashboard.newWidget()
+w['name'] = 'Time Series'
+w['viewPath'] = 'Mes/Widgets/TimeSeries'
+saved = system.mes.dashboard.saveWidget(w)
+print(saved)
+```

--- a/docs/appendix/script-api/dashboard-script-api/save-dashboard.md
+++ b/docs/appendix/script-api/dashboard-script-api/save-dashboard.md
@@ -1,0 +1,55 @@
+---
+sidebar_position: 29
+title: "saveDashboard"
+description: "Creates or updates a dashboard with specified parameters."
+---
+
+# system.mes.dashboard.saveDashboard
+
+## Description
+
+Creates or updates a Dashboard in the system based on the provided parameters.
+
+## Syntax
+
+```python
+system.mes.dashboard.saveDashboard(**dashboard)
+```
+
+## Parameters
+
+| Parameter          | Type            | Nullable | Description                                                          |
+|--------------------|-----------------|----------|----------------------------------------------------------------------|
+| `name`             | `String`        | False    | The user-given name for the dashboard.                               |
+| `url`              | `String`        | False    | URL-friendly version used for page routing.                          |
+| `isPublic`         | `Boolean`       | False    | True if the dashboard is public.                                     |
+| `username`         | `String`        | True     | Owner’s Ignition username (null if public).                          |
+| `iconPath`         | `String`        | True     | Path to an icon for the dashboard.                                   |
+| `pack`             | `Boolean`       | False    | When true, sizes to fit content; otherwise uses fixed grid settings. |
+| `grid`             | `String`        | False    | Grid layout mode (e.g., STRETCH).                                    |
+| `rowCount`         | `Integer`       | False    | Number of grid rows (fixed layout).                                  |
+| `columnCount`      | `Integer`       | False    | Number of grid columns (fixed layout).                               |
+| `rowGutterSize`    | `Integer`       | False    | Vertical spacing between rows (fixed layout).                        |
+| `columnGutterSize` | `Integer`       | False    | Horizontal spacing between columns (fixed layout).                   |
+| `instancesJson`    | `String`        | False    | JSON for Perspective dashboard component `props.instances`.          |
+| `id`               | `String` (ULID) | True     | The ULID of the dashboard (optional, for updates).                   |
+| `notes`            | `String`        | True     | Notes related to the dashboard.                                      |
+| `enabled`          | `Boolean`       | True     | Indicates if the dashboard is active and enabled.                    |
+| `spare1`           | `String`        | True     | Additional field for user-defined context.                           |
+| `spare2`           | `String`        | True     | Additional field for user-defined context.                           |
+| `spare3`           | `String`        | True     | Additional field for user-defined context.                           |
+
+## Returns
+
+Returns a JSON representation of the saved dashboard.
+
+## Code Examples
+
+```python
+db = system.mes.dashboard.newDashboard()
+db['name'] = 'Production Overview'
+db['url'] = 'production-overview'
+db['instancesJson'] = '[]'
+saved = system.mes.dashboard.saveDashboard(**db)
+print(saved)
+```

--- a/docs/appendix/script-api/dashboard-script-api/save-parameter-type.md
+++ b/docs/appendix/script-api/dashboard-script-api/save-parameter-type.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 6
+title: "saveParameterType"
+description: "Creates or updates a dashboard widget parameter type."
+---
+
+# system.mes.dashboard.saveParameterType
+
+## Description
+
+Creates or updates a Dashboard Widget Parameter Type in the system based on the provided parameters.
+
+## Syntax
+
+```python
+system.mes.dashboard.saveParameterType(**parameter_type)
+```
+
+## Parameters
+
+| Parameter  | Type            | Nullable | Description                                             |
+|------------|-----------------|----------|---------------------------------------------------------|
+| `name`     | `String`        | False    | The unique name of the parameter type.                  |
+| `viewPath` | `String`        | False    | Perspective view path used to edit this parameter type. |
+| `id`       | `String` (ULID) | True     | The ULID of the parameter type (for updates).           |
+| `notes`    | `String`        | True     | Notes related to the parameter type.                    |
+| `enabled`  | `Boolean`       | True     | Indicates if the parameter type is active and enabled.  |
+| `spare1`   | `String`        | True     | Additional field for user-defined context.              |
+| `spare2`   | `String`        | True     | Additional field for user-defined context.              |
+| `spare3`   | `String`        | True     | Additional field for user-defined context.              |
+
+## Returns
+
+Returns a JSON representation of the saved parameter type.
+
+## Code Examples
+
+```python
+pt = system.mes.dashboard.newParameterType()
+pt['name'] = 'Integer'
+pt['viewPath'] = 'Mes/Editors/Integer'
+saved = system.mes.dashboard.saveParameterType(pt)
+print(saved)
+```

--- a/docs/appendix/script-api/dashboard-script-api/save-widget-and-parameters.md
+++ b/docs/appendix/script-api/dashboard-script-api/save-widget-and-parameters.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 15
+title: "saveWidgetAndParameters"
+description: "Saves a widget and its parameters in one call, removing parameters not in the list."
+---
+
+# system.mes.dashboard.saveWidgetAndParameters
+
+## Description
+
+Saves or updates a Dashboard Widget and its associated parameters in a single call. Parameters provided are
+saved/updated; parameters not included are removed from the widget.
+
+## Syntax
+
+```python
+system.mes.dashboard.saveWidgetAndParameters(widget, parameters)
+```
+
+## Parameters
+
+| Parameter    | Type                | Nullable | Description                                          |
+|--------------|---------------------|----------|------------------------------------------------------|
+| `widget`     | `JSON Object`       | False    | The widget to save (same structure as saveWidget).   |
+| `parameters` | `List<JSON Object>` | False    | List of parameter DTOs to associate with the widget. |
+
+## Returns
+
+Returns a JSON representation of the saved widget.
+
+## Code Examples
+
+```python
+widget = system.mes.dashboard.newWidget()
+widget['name'] = 'Time Series'
+widget['viewPath'] = 'Mes/Widgets/TimeSeries'
+
+p1 = system.mes.dashboard.newWidgetParameter()
+p1['name'] = 'Chart Title'
+p1['parameterKey'] = 'title'
+
+saved = system.mes.dashboard.saveWidgetAndParameters(widget, [p1])
+print(saved)
+```

--- a/docs/appendix/script-api/dashboard-script-api/save-widget-parameter.md
+++ b/docs/appendix/script-api/dashboard-script-api/save-widget-parameter.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 24
+title: "saveWidgetParameter"
+description: "Creates or updates a dashboard widget parameter with specified parameters."
+---
+
+# system.mes.dashboard.saveWidgetParameter
+
+## Description
+
+Creates or updates a Dashboard Widget Parameter in the system based on the provided parameters.
+
+## Syntax
+
+```python
+system.mes.dashboard.saveWidgetParameter(widgetParameter)
+```
+
+## Parameters
+
+| Parameter         | Type          | Nullable | Description                                                       |
+|-------------------|---------------|----------|-------------------------------------------------------------------|
+| `widgetParameter` | `JSON Object` | False    | The widget parameter to save. Accepts any serializable parameter. |
+
+## Returns
+
+Returns a JSON representation of the saved widget parameter.
+
+## Code Examples
+
+```python
+p = system.mes.dashboard.newWidgetParameter()
+p['widgetId'] = '01JAP8RJBN-8ZTPXSGY-J9GSDPE1'
+p['name'] = 'Chart Title'
+p['parameterKey'] = 'title'
+saved = system.mes.dashboard.saveWidgetParameter(p)
+print(saved)
+```

--- a/docs/appendix/script-api/dashboard-script-api/save-widget.md
+++ b/docs/appendix/script-api/dashboard-script-api/save-widget.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 14
+title: "saveWidget"
+description: "Creates or updates a dashboard widget with specified parameters."
+---
+
+# system.mes.dashboard.saveWidget
+
+## Description
+
+Creates or updates a Dashboard Widget in the system based on the provided parameters.
+
+## Syntax
+
+```python
+system.mes.dashboard.saveWidget(**widget)
+```
+
+## Parameters
+
+| Parameter       | Type            | Nullable | Description                                        |
+|-----------------|-----------------|----------|----------------------------------------------------|
+| `name`          | `String`        | False    | The user-friendly name of the widget.              |
+| `description`   | `String`        | True     | Description of the widget functionality.           |
+| `viewPath`      | `String`        | False    | Path to the Ignition View that renders the widget. |
+| `iconPath`      | `String`        | True     | Path to an icon for the widget.                    |
+| `category`      | `String`        | True     | Category of the widget.                            |
+| `defaultWidth`  | `Integer`       | False    | Default grid width of the widget.                  |
+| `defaultHeight` | `Integer`       | False    | Default grid height of the widget.                 |
+| `minWidth`      | `Integer`       | False    | Minimum grid width allowed.                        |
+| `minHeight`     | `Integer`       | False    | Minimum grid height allowed.                       |
+| `id`            | `String` (ULID) | True     | The ULID of the widget (optional, for updates).    |
+| `notes`         | `String`        | True     | Notes related to the widget.                       |
+| `enabled`       | `Boolean`       | True     | Indicates if the widget is active and enabled.     |
+| `spare1`        | `String`        | True     | Additional field for user-defined context.         |
+| `spare2`        | `String`        | True     | Additional field for user-defined context.         |
+| `spare3`        | `String`        | True     | Additional field for user-defined context.         |
+
+## Returns
+
+Returns a JSON representation of the saved widget.
+
+## Code Examples
+
+```python
+w = system.mes.dashboard.newWidget()
+w['name'] = 'Time Series'
+w['viewPath'] = 'Mes/Widgets/TimeSeries'
+saved = system.mes.dashboard.saveWidget(w)
+print(saved)
+```

--- a/docs/appendix/script-api/dashboard-script-api/save-widgets.md
+++ b/docs/appendix/script-api/dashboard-script-api/save-widgets.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 18
+title: "saveWidgets"
+description: "Saves a list of dashboard widgets in bulk."
+---
+
+# system.mes.dashboard.saveWidgets
+
+## Description
+
+Saves a list of Dashboard Widgets in bulk. Recommended for registering all widgets at gateway startup.
+
+## Syntax
+
+```python
+system.mes.dashboard.saveWidgets(widgets)
+```
+
+## Parameters
+
+| Parameter | Type                | Nullable | Description                          |
+|-----------|---------------------|----------|--------------------------------------|
+| `widgets` | `List<JSON Object>` | False    | List of widget dictionaries to save. |
+
+## Returns
+
+Returns a list of JSON objects representing the saved widgets.
+
+## Code Examples
+
+```python
+w1 = system.mes.dashboard.newWidget(); w1['name'] = 'Time Series'; w1['viewPath'] = 'Mes/Widgets/TimeSeries'
+w2 = system.mes.dashboard.newWidget(); w2['name'] = 'Summary';     w2['viewPath'] = 'Mes/Widgets/Summary'
+saved = system.mes.dashboard.saveWidgets([w1, w2])
+print(saved)
+```

--- a/docs/appendix/script-api/dashboard-script-api/validate-dashboard.md
+++ b/docs/appendix/script-api/dashboard-script-api/validate-dashboard.md
@@ -1,0 +1,53 @@
+---
+sidebar_position: 30
+title: "validateDashboard"
+description: "Validates a dashboard and returns any validation errors."
+---
+
+# system.mes.dashboard.validateDashboard
+
+## Description
+
+Validates the specified parameters for a Dashboard and returns any validation errors. This does not save the object.
+
+## Syntax
+
+```python
+system.mes.dashboard.validateDashboard(**dashboard)
+```
+
+## Parameters
+
+| Parameter          | Type            | Nullable | Description                                                          |
+|--------------------|-----------------|----------|----------------------------------------------------------------------|
+| `name`             | `String`        | False    | The user-given name for the dashboard.                               |
+| `url`              | `String`        | False    | URL-friendly version used for page routing.                          |
+| `isPublic`         | `Boolean`       | False    | True if the dashboard is public.                                     |
+| `username`         | `String`        | True     | Owner’s Ignition username (null if public).                          |
+| `iconPath`         | `String`        | True     | Path to an icon for the dashboard.                                   |
+| `pack`             | `Boolean`       | False    | When true, sizes to fit content; otherwise uses fixed grid settings. |
+| `grid`             | `String`        | False    | Grid layout mode (e.g., STRETCH).                                    |
+| `rowCount`         | `Integer`       | False    | Number of grid rows (fixed layout).                                  |
+| `columnCount`      | `Integer`       | False    | Number of grid columns (fixed layout).                               |
+| `rowGutterSize`    | `Integer`       | False    | Vertical spacing between rows (fixed layout).                        |
+| `columnGutterSize` | `Integer`       | False    | Horizontal spacing between columns (fixed layout).                   |
+| `instancesJson`    | `String`        | False    | JSON for Perspective dashboard component `props.instances`.          |
+| `id`               | `String` (ULID) | True     | The ULID of the dashboard.                                           |
+| `notes`            | `String`        | True     | Notes related to the dashboard.                                      |
+| `enabled`          | `Boolean`       | True     | Indicates if the dashboard is active and enabled.                    |
+| `spare1`           | `String`        | True     | Additional field for user-defined context.                           |
+| `spare2`           | `String`        | True     | Additional field for user-defined context.                           |
+| `spare3`           | `String`        | True     | Additional field for user-defined context.                           |
+
+## Returns
+
+Returns a JSON object where keys are field names and values are lists of validation violation messages.
+
+## Code Examples
+
+```python
+db = system.mes.dashboard.newDashboard()
+db['name'] = ''  # invalid
+violations = system.mes.dashboard.validateDashboard(**db)
+print(violations)
+```

--- a/docs/appendix/script-api/dashboard-script-api/validate-parameter-type.md
+++ b/docs/appendix/script-api/dashboard-script-api/validate-parameter-type.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 7
+title: "validateParameterType"
+description: "Validates a dashboard widget parameter type and returns any validation errors."
+---
+
+# system.mes.dashboard.validateParameterType
+
+## Description
+
+Validates the specified parameters for a Dashboard Widget Parameter Type and returns any validation errors. This does
+not save the object.
+
+## Syntax
+
+```python
+system.mes.dashboard.validateParameterType(**parameter_type)
+```
+
+## Parameters
+
+| Parameter  | Type            | Nullable | Description                                             |
+|------------|-----------------|----------|---------------------------------------------------------|
+| `name`     | `String`        | False    | The unique name of the parameter type.                  |
+| `viewPath` | `String`        | False    | Perspective view path used to edit this parameter type. |
+| `id`       | `String` (ULID) | True     | The ULID of the parameter type.                         |
+| `notes`    | `String`        | True     | Notes related to the parameter type.                    |
+| `enabled`  | `Boolean`       | True     | Indicates if the parameter type is active and enabled.  |
+| `spare1`   | `String`        | True     | Additional field for user-defined context.              |
+| `spare2`   | `String`        | True     | Additional field for user-defined context.              |
+| `spare3`   | `String`        | True     | Additional field for user-defined context.              |
+
+## Returns
+
+Returns a JSON object where keys are field names and values are lists of validation violation messages.
+
+## Code Examples
+
+```python
+pt = system.mes.dashboard.newParameterType()
+pt['name'] = ''  # invalid
+violations = system.mes.dashboard.validateParameterType(pt)
+print(violations)
+```

--- a/docs/appendix/script-api/dashboard-script-api/validate-widget-parameter.md
+++ b/docs/appendix/script-api/dashboard-script-api/validate-widget-parameter.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 22
+title: "validateWidgetParameter"
+description: "Validates a dashboard widget parameter and returns any validation errors."
+---
+
+# system.mes.dashboard.validateWidgetParameter
+
+## Description
+
+Validates the specified parameters for a Dashboard Widget Parameter and returns any validation errors. This does not
+save the object.
+
+## Syntax
+
+```python
+system.mes.dashboard.validateWidgetParameter(widgetParameter)
+```
+
+## Parameters
+
+| Parameter         | Type          | Nullable | Description                       |
+|-------------------|---------------|----------|-----------------------------------|
+| `widgetParameter` | `JSON Object` | False    | The widget parameter to validate. |
+
+## Returns
+
+Returns a JSON object where keys are field names and values are lists of validation violation messages.
+
+## Code Examples
+
+```python
+p = system.mes.dashboard.newWidgetParameter()
+p['name'] = ''  # invalid
+violations = system.mes.dashboard.validateWidgetParameter(p)
+print(violations)
+```

--- a/docs/appendix/script-api/dashboard-script-api/validate-widget.md
+++ b/docs/appendix/script-api/dashboard-script-api/validate-widget.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 16
+title: "validateWidget"
+description: "Validates a dashboard widget and returns any validation errors."
+---
+
+# system.mes.dashboard.validateWidget
+
+## Description
+
+Validates the specified parameters for a Dashboard Widget and returns any validation errors. This does not save the
+object.
+
+## Syntax
+
+```python
+system.mes.dashboard.validateWidget(**widget)
+```
+
+## Parameters
+
+| Parameter       | Type      | Nullable | Description                                        |
+|-----------------|-----------|----------|----------------------------------------------------|
+| `name`          | `String`  | False    | The user-friendly name of the widget.              |
+| `description`   | `String`  | True     | Description of the widget functionality.           |
+| `viewPath`      | `String`  | False    | Path to the Ignition View that renders the widget. |
+| `iconPath`      | `String`  | True     | Path to an icon for the widget.                    |
+| `category`      | `String`  | True     | Category of the widget.                            |
+| `defaultWidth`  | `Integer` | False    | Default grid width of the widget.                  |
+| `defaultHeight` | `Integer` | False    | Default grid height of the widget.                 |
+| `minWidth`      | `Integer` | False    | Minimum grid width allowed.                        |
+| `minHeight`     | `Integer` | False    | Minimum grid height allowed.                       |
+| `id`            | `String`  | True     | The ULID of the widget.                            |
+| `notes`         | `String`  | True     | Notes related to the widget.                       |
+| `enabled`       | `Boolean` | True     | Indicates if the widget is active and enabled.     |
+| `spare1`        | `String`  | True     | Additional field for user-defined context.         |
+| `spare2`        | `String`  | True     | Additional field for user-defined context.         |
+| `spare3`        | `String`  | True     | Additional field for user-defined context.         |
+
+## Returns
+
+Returns a JSON object where keys are field names and values are lists of validation violation messages.
+
+## Code Examples
+
+```python
+w = system.mes.dashboard.newWidget()
+w['name'] = ''  # invalid
+violations = system.mes.dashboard.validateWidget(w)
+print(violations)
+```


### PR DESCRIPTION
closes [#1484](https://github.com/TamakiControl/tamaki-mes/issues/1484)

This pull request introduces comprehensive documentation for the Dashboard data model and its related script API endpoints. It adds detailed descriptions of the primary dashboard entities, their fields, and the available deletion script methods, making it easier for developers to understand and work with dashboard configuration and management in TamakiMES.

**Dashboard Data Model Documentation:**

* Added a new section to the data model overview describing the Dashboard entities and their role in MES operations (`docs/appendix/data-model/intro.md`).
* Created an overview and individual documentation pages for each dashboard-related entity: `Dashboard`, `DashboardWidget`, `DashboardWidgetParameter`, and `DashboardWidgetParameterType` (`docs/appendix/data-model/dashboard-model/intro.md`, `dashboard.md`, `dashboard-widget.md`, `dashboard-widget-parameter.md`, `dashboard-widget-parameter-type.md`). [[1]](diffhunk://#diff-d5cfa9b44be819bfa9583463c408b3e1c23e7608d7e2d1e57e9d69b59528c36dR1-R20) [[2]](diffhunk://#diff-e7e03162c730f2f13f8973121ced17eb8e83e8595442724cff13306b9a091f4fR1-R57) [[3]](diffhunk://#diff-ab2f48c70dc9381b69da3f01390255e077853b0252a84eaca0a7454dd764ea06R1-R54) [[4]](diffhunk://#diff-ffb6ba53df3833709c4a3cd7078c2a64b3f419014c0fb0cc67cf01da8f0cc451R1-R49) [[5]](diffhunk://#diff-3066d4874671aba6f7307c7e41c58f154bed141533549ec14dd2b04277e77292R1-R38)
* 
**Dashboard Script API Documentation:**

* Added documentation for everything in DashboardScriptApi.java